### PR TITLE
fix: remove paths-ignore from release.yml so content edits fire release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,15 +3,6 @@ name: Release
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - ".github/**"
-      - "docs/**"
-      - "LICENSE"
-      - "README.md"
-      - "AGENTS.md"
-      - "CLAUDE.md"
-      - "CHANGELOG.md"
-      - "ROADMAP.md"
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
Removes the paths-ignore block from release.yml on the push trigger.

Parallel rollout following the Home-Lab canary (TMHSDigital/Home-Lab-Developer-Tools#21, squash SHA b7adc86). Per DTD#47 design proposal (Option A): every push to main should start the release workflow, and commit message prefix decides whether release fires. The previous paths-ignore pattern silently prevented content additions and version-marker edits from firing release-doc-sync reconciliation across the ecosystem.

Diff is removal-only on the push trigger's paths-ignore block. No other on-trigger sections, jobs, or steps are modified.
