### PR TITLE
fix: correctness pass on Blender skills, snippets, and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Small standalone `.py` files at `snippets/<name>.py`, each 5 to 50 lines.
 
 v0.1.0: canonical object creation and deletion, depsgraph evaluated mesh, bmesh load-edit-free, temp_override context, foreach_set vertex bulk write, register_classes_factory, PointerProperty binding, cross-version property delete, and the `action_ensure_channelbag_for_slot` slotted-actions bridge.
 
-v0.2.1: Principled BSDF material, driver-with-custom-function via `driver_namespace`, application handler registration, shader node group with cross-version `interface` API, `foreach_get` bulk vertex read, version-branch skeleton, and USD export with `evaluation_mode='RENDER'`.
+v0.2.0: Principled BSDF material, driver-with-custom-function via `driver_namespace`, application handler registration, shader node group with cross-version `interface` API, `foreach_get` bulk vertex read, version-branch skeleton, and USD export with `evaluation_mode='RENDER'`.
 
 ## Development Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ templates/
 
 - **`skills/`** - one directory per skill, each containing `SKILL.md` with YAML frontmatter (`name`, `description`, `standards-version`).
 - **`rules/`** - Cursor-style rules as `.mdc` files with YAML frontmatter (`description`, `alwaysApply`, `globs`, `standards-version`).
-- **`snippets/`** - small standalone `.py` files (5 to 30 lines) demonstrating a single canonical pattern.
+- **`snippets/`** - small standalone `.py` files (5 to 50 lines) demonstrating a single canonical pattern.
 - **`templates/`** - copy-paste starting points; one directory per template.
 
 ## Adding a Skill
@@ -51,7 +51,7 @@ templates/
    ---
    name: procedural-materials
    description: One-line description, under 200 chars.
-   standards-version: <current meta-repo VERSION>
+   standards-version: <current meta-repo STANDARDS_VERSION>
    ---
    ```
 
@@ -69,7 +69,7 @@ templates/
    alwaysApply: true
    globs:
      - "**/*.py"
-   standards-version: <current meta-repo VERSION>
+   standards-version: <current meta-repo STANDARDS_VERSION>
    ---
    ```
 
@@ -78,7 +78,7 @@ templates/
 ## Adding a Snippet
 
 1. Add a `.py` file under `snippets/`, e.g. `snippets/depsgraph-evaluated-mesh.py`.
-2. Keep it 5 to 30 lines, fully working code, with a header comment naming the snippet and citing the relevant Blender doc URL or research section.
+2. Keep it 5 to 50 lines, fully working code, with a header comment naming the snippet and citing the relevant Blender doc URL or research section.
 3. Snippets are validated for Python syntax in CI.
 
 ## Adding a Template
@@ -101,10 +101,10 @@ else:
 
 ## Standards-version Markers
 
-Files that participate in ecosystem drift checking must carry a `standards-version` marker matching the current meta-repo `VERSION`:
+Files that participate in ecosystem drift checking must carry a `standards-version` marker matching the current meta-repo `STANDARDS_VERSION` (which is decoupled from this repo's `VERSION`):
 
-- `AGENTS.md`, `CLAUDE.md`, `ROADMAP.md`: HTML comment first line, e.g. `<!-- standards-version: 1.9.1 -->`.
-- `skills/*/SKILL.md`, `rules/*.mdc`: YAML frontmatter field `standards-version: 1.9.1`.
+- `AGENTS.md`, `CLAUDE.md`, `ROADMAP.md`: HTML comment first line, e.g. `<!-- standards-version: <STANDARDS_VERSION> -->`.
+- `skills/*/SKILL.md`, `rules/*.mdc`: YAML frontmatter field `standards-version: <STANDARDS_VERSION>`.
 
 The drift-check workflow enforces these on every push and PR.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/TMHSDigital/Blender-Developer-Tools/releases"><img src="https://img.shields.io/badge/version-0.2.0-e87d0d?style=flat-square" alt="Version" /></a>
   <a href="https://github.com/TMHSDigital/Blender-Developer-Tools/releases"><img src="https://img.shields.io/github/v/release/TMHSDigital/Blender-Developer-Tools?style=flat-square&color=e87d0d&label=release" alt="Release" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-CC--BY--NC--ND--4.0-384d54?style=flat-square" alt="License" /></a>
 </p>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@
 | Version | Theme | Skills | Rules | Templates | Snippets | Status |
 | --- | --- | --- | --- | --- | --- | --- |
 | v0.1.0 | Foundation | 8 | 4 | 1 | 10 | Shipped |
-| v0.2.0 | Materials, drivers, migration | 12 | 6 | 2 | 17 | **Current** |
+| v0.2.0 | Materials, drivers, migration | 12 | 6 | 2 | 17 | Shipped |
 | v0.3.0 | 5.2 LTS sweep, modal operators, USD | TBD | TBD | TBD | TBD | Planned |
 | v1.0.0 | Stable | TBD | TBD | TBD | TBD | Planned |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ Please include:
 
 ## Scope
 
-This repository ships Markdown skill files, MDC rule files, Python snippets, and one Blender extension add-on template. The primary security concerns are:
+This repository ships Markdown skill files, MDC rule files, Python snippets, and two starter templates (a Blender extension add-on and a headless batch script). The primary security concerns are:
 
 - **Snippets or templates demonstrating insecure patterns** (executing arbitrary code from `.blend` files, loading remote scripts without validation, leaking filesystem paths into logs).
 - **The extension-addon template declaring over-broad permissions** in `blender_manifest.toml` (e.g. `network`, `files`, `clipboard`, `camera`) without a documented justification.
@@ -28,8 +28,8 @@ Issues with the Blender Python API itself (`bpy`, `bmesh`, `bpy_extras`) belong 
 
 | Version | Supported |
 |---------|-----------|
-| 0.1.x   | Yes       |
-| < 0.1.0 | No        |
+| 0.2.x   | Yes       |
+| < 0.2.0 | No        |
 
 ## Response Timeline
 

--- a/skills/custom-properties/SKILL.md
+++ b/skills/custom-properties/SKILL.md
@@ -133,11 +133,11 @@ The order matters. The bound `PointerProperty` references the `PropertyGroup` cl
 
 ```python
 def unregister():
-    del bpy.types.Scene.my_addon  # or property_unset() on 5.0+
+    del bpy.types.Scene.my_addon
     bpy.utils.unregister_class(MY_ADDON_PG_settings)
 ```
 
-See the snippet `cross-version-property-delete.py` for the 5.0+ `property_unset` shape and the 4.5 LTS `del` shape.
+Unbinding a type-level property is `del bpy.types.Scene.my_addon` on all Blender versions. See the snippet `cross-version-property-delete.py` for removing a custom ID property (also `del`, version-stable).
 
 ## CollectionProperty (lists)
 
@@ -231,7 +231,12 @@ This is a frequent AI mistake when generating quick scripts. Always wrap state i
 
 ## Compatibility paths (4.5 LTS vs 5.0+)
 
-In Blender 5.0+, `bpy.types.Scene.my_addon.property_unset(...)` is the preferred unbind for individual props. In 4.5 LTS, `del bpy.types.Scene.my_addon` is still required for `PointerProperty` bindings. The snippet `cross-version-property-delete.py` shows both.
+Two distinct operations, both version-stable via `del`:
+
+- **Unbind a type-level property** (e.g. a `PointerProperty` bound to `bpy.types.Scene`): `del bpy.types.Scene.my_addon`. Same on 4.5 LTS and 5.0+.
+- **Remove a custom ID property** (the dict-style `obj["key"]`): `del obj["key"]`. Same on 4.5 LTS and 5.0+. The snippet `cross-version-property-delete.py` shows this.
+
+Do not reach for `property_unset()` here. It resets a registered RNA property to its default, which is neither unbinding a type property nor removing an ID property.
 
 ## Related
 

--- a/skills/operators/SKILL.md
+++ b/skills/operators/SKILL.md
@@ -129,6 +129,7 @@ Pair `report({'ERROR'}, ...)` with `return {'CANCELLED'}` so the operator does n
 
 ```python
 import bpy
+from mathutils import Vector
 
 
 class OBJECT_OT_offset_active(bpy.types.Operator):
@@ -157,7 +158,10 @@ class OBJECT_OT_offset_active(bpy.types.Operator):
         offset = (self.offset_x, self.offset_y, self.offset_z)
 
         if self.use_local:
-            obj.location += obj.matrix_world.to_3x3() @ bpy.types.Vector(offset)
+            # Column-normalize the basis so object scale does not distort the
+            # local-axis direction; to_3x3() alone carries scale into the result.
+            basis = obj.matrix_world.to_3x3().normalized()
+            obj.location += basis @ Vector(offset)
         else:
             obj.location.x += self.offset_x
             obj.location.y += self.offset_y

--- a/snippets/cross-version-property-delete.py
+++ b/snippets/cross-version-property-delete.py
@@ -1,7 +1,10 @@
-# Cross-version property deletion: property_unset (5.0+) vs del (4.5 LTS).
-# Custom ID properties (the dict-style obj["my_key"] = value) are removed
-# differently across Blender versions. property_unset is the cleaner
-# 5.x-and-up form; del obj["key"] still works on 4.5 LTS.
+# Removing a custom ID property (the dict-style obj["my_key"] = value).
+# ID-property removal is version-stable: `del id_block[key]` works on all
+# Blender versions (4.5 LTS and 5.x alike). There is no version branch here.
+#
+# Do NOT use property_unset() for this. property_unset() RESETS a registered
+# RNA property to its default value; it does not remove a custom ID property.
+# That is a different operation.
 #
 # Reference:
 #   https://docs.blender.org/api/current/bpy.types.bpy_struct.html
@@ -13,11 +16,7 @@ def remove_custom_property(id_block, key):
     if key not in id_block.keys():
         return False
 
-    if bpy.app.version >= (5, 0, 0):
-        id_block.property_unset(key)
-    else:
-        del id_block[key]
-
+    del id_block[key]
     return True
 
 

--- a/snippets/shader-node-group.py
+++ b/snippets/shader-node-group.py
@@ -23,10 +23,15 @@ def make_tint_group(name="Tint"):
 
     group_in = nodes.new('NodeGroupInput')
     group_out = nodes.new('NodeGroupOutput')
-    mix = nodes.new('ShaderNodeMixRGB')
+    mix = nodes.new('ShaderNodeMix')
+    mix.data_type = 'RGBA'
     mix.blend_type = 'MULTIPLY'
 
-    links.new(group_in.outputs['Color'], mix.inputs['Color1'])
-    links.new(group_in.outputs['Strength'], mix.inputs['Fac'])
-    links.new(mix.outputs['Color'], group_out.inputs['Result'])
+    # ShaderNodeMix shares socket names (Factor/A/B/Result) across every
+    # data_type, so name lookup is ambiguous. Wire the RGBA sockets by index:
+    #   inputs[0]=Factor (Float), inputs[6]=A (Color), inputs[7]=B (Color)
+    #   outputs[2]=Result (Color)
+    links.new(group_in.outputs['Strength'], mix.inputs[0])
+    links.new(group_in.outputs['Color'], mix.inputs[6])
+    links.new(mix.outputs[2], group_out.inputs['Result'])
     return group

--- a/snippets/version-branch-skeleton.py
+++ b/snippets/version-branch-skeleton.py
@@ -6,18 +6,17 @@ import bpy
 
 
 def clear_property(obj, key):
-    """Delete a custom property cross-version.
+    """Delete a custom ID property.
 
-    Blender 5.0 introduced property_unset() as the supported path; on 4.5 LTS
-    fall back to del obj[key]. Either form raises if key is absent, so check first.
+    NOT version-dependent: del obj[key] works on every Blender version
+    (4.5 LTS and 5.x). del raises if key is absent, so check membership first.
+    See get_eevee_engine_id() below for the file's genuine version-divergence
+    example.
     """
     if key not in obj:
         return False
 
-    if bpy.app.version >= (5, 0, 0):
-        obj.property_unset(f'["{key}"]')
-    else:
-        del obj[key]
+    del obj[key]
     return True
 
 


### PR DESCRIPTION
## Summary

Correctness pass across skills, snippets, and docs. No content added or removed, so aggregate counts are unchanged (validate-counts stays green).

### Code bugs (what the AI serves users)

1. **operators/SKILL.md** — `OBJECT_OT_offset_active` called `bpy.types.Vector(offset)`; `Vector` lives in `mathutils`. Added `from mathutils import Vector` and use `Vector(offset)`. Also column-normalized the basis (`matrix_world.to_3x3().normalized()`) so object scale no longer distorts a local-axis direction.
2. **cross-version-property-delete.py** — `property_unset()` *resets* a registered RNA prop to default; it does not remove a custom ID property. Dropped the `bpy.app.version` branch; `del id_block[key]` is version-stable on all versions. Header now documents the distinction so readers don't reintroduce it.
3. **version-branch-skeleton.py** — `clear_property()` used `property_unset` as a "divergence" example, but `del` works on both 4.5 LTS and 5.x (not divergent). Now `del obj[key]` unconditionally; `get_eevee_engine_id()` remains the genuine divergence example.
4. **custom-properties/SKILL.md** — Removed the "(or property_unset() on 5.0+)" parenthetical from the unbind example and rewrote the "Compatibility paths" section. Both unbinding a type-level `PointerProperty` and removing an ID property are version-stable via `del`; `property_unset` is explicitly called out as a different operation.
5. **shader-node-group.py** — Modernized `ShaderNodeMixRGB` → `ShaderNodeMix` with `data_type='RGBA'`, consistent with the geometry-nodes-python skill. Verified against the [ShaderNodeMix docs](https://docs.blender.org/api/current/bpy.types.ShaderNodeMix.html): the node shares socket names (`Factor`/`A`/`B`/`Result`) across every data type, so name lookup is ambiguous — wired the RGBA sockets by index (`inputs[0]` Factor, `inputs[6]` A, `outputs[2]` Result).

### Doc drift

6. **README.md** — Removed the hardcoded `version-0.2.0` shields badge that drifts every release. The dynamic `github/v/release` badge already covers it (root-cause fix, not a re-hardcode).
7. **ROADMAP.md** — v0.2.0 row status `**Current**` → `Shipped` and dropped the per-row marker, so the action-owned `**Current:**` prose line is the single source of truth. The `**Current:**` line itself was not touched.
8. **SECURITY.md** — Supported Versions `0.1.x` → `0.2.x`; scope text "one ... template" → two templates.
9. **CONTRIBUTING.md** — Snippet length `5 to 30` → `5 to 50` (matches README/CLAUDE). Replaced hardcoded `1.9.1` standards-version markers with a pointer to the meta-repo `STANDARDS_VERSION`, and fixed wording from `VERSION` to `STANDARDS_VERSION` (the two are decoupled).
10. **CLAUDE.md** — Relabeled the 7 materials/drivers/migration snippets from `v0.2.1` to `v0.2.0` to match ROADMAP/CHANGELOG/README. The `**Version:**` line was not touched.

### Flag for a separate meta-repo look

The `v0.2.0` → `v0.2.1` mangling of historical snippet text in CLAUDE.md looks like the `release-doc-sync` step running a find/replace that caught a non-current version reference. Worth auditing the action so it only rewrites the current-version prose and leaves historical attributions alone.

### Out of scope (per request)

- No `standards-version` markers in live files touched (left at 1.9.4); no `.github/workflows` changes — owned by the separate fleet-onboarding op.
- Action-owned lines untouched: CLAUDE.md `**Version:**`, ROADMAP.md `**Current:**`, CHANGELOG.md.

## Test plan

- [x] `python -m py_compile` on all three edited snippets passes.
- [x] Aggregate counts unchanged → validate-counts green.
- [x] No stray `property_unset`/`ShaderNodeMixRGB`/`bpy.types.Vector`/`version-0.2.0` references remain.
