### PR TITLE
chore: onboard to Developer-Tools-Directory standards 1.10.0

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
-      - uses: TMHSDigital/Developer-Tools-Directory/.github/actions/drift-check@v1.9
+      - uses: TMHSDigital/Developer-Tools-Directory/.github/actions/drift-check@v1.15
         with:
           mode: self
           format: gh-summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           plugin-version: ${{ steps.new.outputs.version }}
           previous-version: ${{ steps.current.outputs.version }}
-          meta-repo-ref: v1.9.1
+          meta-repo-ref: v1.15.1
 
       - name: Commit version bump
         if: steps.check.outputs.skip == 'false'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: "This issue has been automatically marked as stale due to inactivity. It will be closed in 7 days if no further activity occurs."
+          stale-pr-message: "This PR has been automatically marked as stale due to inactivity. It will be closed in 7 days if no further activity occurs."
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-label: stale
+          stale-pr-label: stale

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-<!-- standards-version: 1.9.4 -->
+<!-- standards-version: 1.10.0 -->
 
 # AGENTS.md
 
@@ -74,7 +74,7 @@ Each skill lives at `skills/<skill-name>/SKILL.md`. Frontmatter is YAML:
 ---
 name: <kebab-case-skill-name>
 description: <one-line, under 200 chars>
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 ```
 
@@ -93,7 +93,7 @@ Rules are `.mdc` files in `rules/`. Frontmatter:
 ---
 description: <one-line>
 alwaysApply: true
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 ```
 
@@ -107,7 +107,7 @@ way, and a one-paragraph rationale. 30 to 80 lines is the right size.
   snippets) match filesystem reality. The counts language in `README.md` is
   load-bearing: the job greps for it.
 - `drift-check.yml` consumes `Developer-Tools-Directory/.github/actions/
-  drift-check@v1.9` to enforce ecosystem standards-version markers.
+  drift-check@v1.15` to enforce ecosystem standards-version markers.
 - `release.yml` auto-bumps the version, tags, force-updates floating tags
   `v0` and `v0.1`, and runs `release-doc-sync@v1` to rewrite CHANGELOG.md,
   CLAUDE.md `**Version:**`, and ROADMAP.md `**Current:**`. Triggered on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- standards-version: 1.9.4 -->
+<!-- standards-version: 1.10.0 -->
 
 # CLAUDE.md
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-<!-- standards-version: 1.9.4 -->
+<!-- standards-version: 1.10.0 -->
 
 # Roadmap
 

--- a/rules/always-free-bmesh.mdc
+++ b/rules/always-free-bmesh.mdc
@@ -3,7 +3,7 @@ description: Flag bmesh.new() calls without a paired bm.free() in a try/finally 
 alwaysApply: true
 globs:
   - "**/*.py"
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # Always free bmesh

--- a/rules/prefer-data-over-ops-in-loops.mdc
+++ b/rules/prefer-data-over-ops-in-loops.mdc
@@ -3,7 +3,7 @@ description: Flag bpy.ops.* calls inside iteration over many objects, meshes, or
 alwaysApply: true
 globs:
   - "**/*.py"
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # Prefer bpy.data over bpy.ops in loops

--- a/rules/prefer-temp-override-over-context-copy.mdc
+++ b/rules/prefer-temp-override-over-context-copy.mdc
@@ -3,7 +3,7 @@ description: Flag uses of `bpy.context.copy()` to override context for an operat
 alwaysApply: true
 globs:
   - "**/*.py"
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # Prefer `temp_override` over `context.copy()`

--- a/rules/target-extensions-platform-format.mdc
+++ b/rules/target-extensions-platform-format.mdc
@@ -4,7 +4,7 @@ alwaysApply: true
 globs:
   - "**/__init__.py"
   - "**/blender_manifest.toml"
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # Target Extensions Platform format

--- a/rules/type-annotate-props-and-defend-context.mdc
+++ b/rules/type-annotate-props-and-defend-context.mdc
@@ -3,7 +3,7 @@ description: Flag two related anti-patterns. (1) bpy.props defined as class-leve
 alwaysApply: true
 globs:
   - "**/*.py"
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # Type-annotate props and defend context

--- a/rules/use-foreach-set-for-bulk-data.mdc
+++ b/rules/use-foreach-set-for-bulk-data.mdc
@@ -3,7 +3,7 @@ description: Flag Python loops that set vertex coordinates, normals, UVs, or oth
 alwaysApply: true
 globs:
   - "**/*.py"
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # Use `foreach_set` and `foreach_get` for bulk mesh data

--- a/skills/addon-scaffolding/SKILL.md
+++ b/skills/addon-scaffolding/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: addon-scaffolding
 description: Scaffold a Blender add-on against the Extensions Platform format with blender_manifest.toml, modular file layout, and the register_classes_factory pattern. Targets Blender 5.1 with 4.5 LTS fallback.
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # Addon Scaffolding (Extensions Platform)

--- a/skills/bl-info-migration/SKILL.md
+++ b/skills/bl-info-migration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: bl-info-migration
 description: Migrate a legacy bl_info-format add-on to the Extensions Platform. Three concrete steps, before-and-after diff, dual-format pattern for backward compatibility, and answers to "is bl_info still supported?" Targets Blender 5.1.
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # bl_info Migration to the Extensions Platform

--- a/skills/custom-properties/SKILL.md
+++ b/skills/custom-properties/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: custom-properties
 description: Define and bind Blender custom properties via bpy.props using the type annotation form, with PropertyGroup for grouping, PointerProperty for binding, and the four storage location options for Scene/Object/WindowManager/AddonPreferences. Targets 5.1.
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # Custom Properties

--- a/skills/depsgraph-and-evaluated-data/SKILL.md
+++ b/skills/depsgraph-and-evaluated-data/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: depsgraph-and-evaluated-data
 description: Read the actual evaluated geometry the user sees by going through the dependency graph rather than reading raw `obj.data`. Covers `evaluated_get`, `to_mesh`, `to_mesh_clear`, and the lifetime rules that prevent crashes and memory leaks. Targets Blender 5.1.
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # Depsgraph and Evaluated Data

--- a/skills/drivers-and-app-handlers/SKILL.md
+++ b/skills/drivers-and-app-handlers/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: drivers-and-app-handlers
 description: Drive properties from expressions or other properties via the Driver API, and react to scene events via the bpy.app.handlers callbacks. Covers driver_namespace for Python functions, the new exit_pre handler in 5.1, and the must-be-fast contract for any handler.
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # Drivers and Application Handlers

--- a/skills/geometry-nodes-python/SKILL.md
+++ b/skills/geometry-nodes-python/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: geometry-nodes-python
 description: Programmatically construct Geometry Nodes trees in Blender 5.x via bpy.data.node_groups, interface socket creation, node instantiation by RNA name, link wiring, and applying as a NODES modifier. Includes Bundles for grouped sockets.
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # Geometry Nodes in Python

--- a/skills/headless-batch-scripting/SKILL.md
+++ b/skills/headless-batch-scripting/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: headless-batch-scripting
 description: Run Blender headless via blender --background --python script.py for batch jobs. What changes without a UI, how to avoid UI-dependent operators, the temp_override pattern when ops must be used, and argparse after the -- separator.
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # Headless Batch Scripting

--- a/skills/mesh-editing-and-bmesh/SKILL.md
+++ b/skills/mesh-editing-and-bmesh/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mesh-editing-and-bmesh
 description: Performant mesh manipulation in Blender. When to use bpy.data vs bpy.ops vs bmesh, the canonical bm.new/free pattern, foreach_set bulk vertex injection, and depsgraph evaluation for modifier-applied geometry. Targets 5.1.
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # Mesh Editing and bmesh

--- a/skills/operators/SKILL.md
+++ b/skills/operators/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: operators
 description: Author Blender operators with bpy.types.Operator, bl_idname conventions, the poll/invoke/execute/modal lifecycle, REGISTER and UNDO options, and defensive context handling. Targets 5.1 with 4.5 LTS compatibility.
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # Operators

--- a/skills/procedural-materials-and-shaders/SKILL.md
+++ b/skills/procedural-materials-and-shaders/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: procedural-materials-and-shaders
 description: Build materials and shader graphs from Python by enabling nodes, instantiating shader nodes, setting socket default values, and wiring links. Targets Blender 5.1 EEVEE Next and Cycles. Avoids the (deferred to 2027) Layered Textures roadmap.
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # Procedural Materials and Shaders

--- a/skills/slotted-actions-animation/SKILL.md
+++ b/skills/slotted-actions-animation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: slotted-actions-animation
 description: Animate from Python under the Blender 5.x Slotted Actions architecture. Action contains Layers contain Strips contain Channelbags. The action_ensure_channelbag_for_slot bridge utility for 4.5 LTS and 5.x compatibility.
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # Slotted Actions Animation

--- a/skills/ui-panels/SKILL.md
+++ b/skills/ui-panels/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ui-panels
 description: Author Blender UI panels with bpy.types.Panel, declarative draw(), bl_space_type and bl_region_type, layout primitives like row/column/split, and conditional UI via .enabled. Targets 5.1.
-standards-version: 1.9.4
+standards-version: 1.10.0
 ---
 
 # UI Panels


### PR DESCRIPTION
## Summary

Reconciles Blender-Developer-Tools against the Developer-Tools-Directory fleet standard. The repo had drifted: standards markers at `1.9.4` while the meta-repo `STANDARDS_VERSION` is `1.10.0`, workflow refs on the old `@v1.9` train, and the required `stale.yml` workflow missing.

### Changes

- **Re-stamp standards-version `1.9.4` -> `1.10.0`** (read live from the meta-repo `STANDARDS_VERSION`) across all 12 skills, 6 rules, and the `AGENTS.md` / `CLAUDE.md` / `ROADMAP.md` markers. This clears the 20 `version-signal` drift errors (AGENTS + CLAUDE + 12 `SKILL.md` + 6 `.mdc`).
- **Bump workflow refs** to the meta-repo's current tags, following the pinning convention documented in the meta-repo release workflow (drift-check pins to the MAJOR.MINOR train, release-doc-sync to the MAJOR train):
  - `drift-check@v1.9` -> `@v1.15` (current MAJOR.MINOR)
  - `release.yml` `meta-repo-ref: v1.9.1` -> `v1.15.1` (current patch)
  - `release-doc-sync@v1` left as-is (MAJOR train already tracks current)
  - `AGENTS.md` CI description updated to `@v1.15` to match
- **Add `stale.yml`** from the scaffold standard. For Plugin-type repos the required workflow set is validate/release/stale/drift-check; `stale.yml` was the gap. `label-sync.yml` stays (optional).

### Not touched

- Action-owned lines: `CLAUDE.md` `**Version:**`, `ROADMAP.md` `**Current:**`, `CHANGELOG.md` (including its historical `@v1.9` mention).
- No standards-version values left at `1.9.4` except the historical ROADMAP changelog prose (`bumped from 1.9.1 to 1.9.4`), which is a statement of past fact.

## Test plan

- [x] No `standards-version: 1.9.4` markers remain (only historical prose).
- [x] `drift-check.yml` -> `@v1.15`, `release.yml` `meta-repo-ref` -> `v1.15.1`.
- [x] `stale.yml` present and well-formed.
- [ ] Post-merge `drift-check` run reports 0 errors; release cuts the next patch.
