### PR TITLE
chore: add .cursor-plugin/plugin.json manifest

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "blender-developer-tools",
+  "displayName": "Blender Developer Tools",
+  "description": "Cursor and Claude Code skills, rules, snippets, and templates for Blender Python add-on and scripting development",
+  "version": "0.2.3",
+  "author": {
+    "name": "TMHSDigital",
+    "email": "contact@users.noreply.github.com"
+  },
+  "license": "CC-BY-NC-ND-4.0",
+  "keywords": [
+    "cursor-plugin",
+    "developer-tools",
+    "blender"
+  ],
+  "skills": [
+    "skills/addon-scaffolding/SKILL.md",
+    "skills/operators/SKILL.md",
+    "skills/ui-panels/SKILL.md",
+    "skills/custom-properties/SKILL.md",
+    "skills/mesh-editing-and-bmesh/SKILL.md",
+    "skills/headless-batch-scripting/SKILL.md",
+    "skills/slotted-actions-animation/SKILL.md",
+    "skills/geometry-nodes-python/SKILL.md",
+    "skills/procedural-materials-and-shaders/SKILL.md",
+    "skills/depsgraph-and-evaluated-data/SKILL.md",
+    "skills/drivers-and-app-handlers/SKILL.md",
+    "skills/bl-info-migration/SKILL.md"
+  ],
+  "rules": [
+    "rules/prefer-data-over-ops-in-loops.mdc",
+    "rules/always-free-bmesh.mdc",
+    "rules/target-extensions-platform-format.mdc",
+    "rules/type-annotate-props-and-defend-context.mdc",
+    "rules/prefer-temp-override-over-context-copy.mdc",
+    "rules/use-foreach-set-for-bulk-data.mdc"
+  ]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,10 @@ Guidance for AI coding agents working on the Blender Developer Tools repository.
 
 Skills, rules, snippets, and a starter template for Blender Python development.
 The repo targets **Blender 5.1** (current stable) with a **Blender 4.5 LTS**
-fallback. There is no MCP server and no `.cursor-plugin/plugin.json`. This is
-content the AI loads when the user asks Blender questions or works on Blender
-add-ons in Cursor or Claude Code.
+fallback. There is no MCP server. It ships a `.cursor-plugin/plugin.json`
+manifest so the ecosystem drift checker classifies it as a `cursor-plugin`.
+This is content the AI loads when the user asks Blender questions or works on
+Blender add-ons in Cursor or Claude Code.
 
 The content base as of v0.2.0:
 


### PR DESCRIPTION
## Summary

Follow-up to #4. That PR re-stamped standards to `1.10.0`, bumped workflow refs to `@v1.15`, and added `stale.yml` — but never added `.cursor-plugin/plugin.json`. The ecosystem drift checker's `_detect_repo_type` keys off that manifest, so the repo still classified as **unknown**, which means `required-workflows` and `required-refs` were silently skipped (the new `stale.yml` and current refs were present but unenforced) and the type disagreed with the registry's `cursor-plugin`.

### Changes

- **Add `.cursor-plugin/plugin.json`** per the scaffold standard (the manifest CFX/Unity/Docker carry): `name`, `displayName`, `description`, `version`, `author`, `license`, `keywords`, and the 12 skill + 6 rule component paths. `_detect_repo_type` now returns `cursor-plugin`.
- **AGENTS.md**: the overview asserted "no `.cursor-plugin/plugin.json`" as a fact about the repo. Updated to state the manifest now ships and why (drift-checker classification). `keywords` use `blender` rather than the scaffold's stock `mcp` since this repo has no MCP server.

### The real test (run locally against this tree with the meta-repo drift checker)

```
repo_type: cursor-plugin
findings: []   (0 errors, 0 warnings)
```

With the type now coherent, `required-workflows` evaluates and passes (validate/release/stale/drift-check all present) and `required-refs` evaluates and passes (empty requirement set for cursor-plugin) — not merely version-signal staying green.

## Test plan

- [x] `plugin.json` valid JSON; all 12+6 component paths resolve to real files.
- [x] Local drift check: `repo_type=cursor-plugin`, 0 errors / 0 warnings.
- [x] `validate.yml` does not inspect `plugin.json` (additive, stays green).
- [ ] Post-merge main: drift-check + release + validate green.
