### PR TITLE
fix: driver_namespace id_type and SDF-grid meshing in skills

### DIFF
--- a/skills/drivers-and-app-handlers/SKILL.md
+++ b/skills/drivers-and-app-handlers/SKILL.md
@@ -69,7 +69,7 @@ fcurve.driver.expression = 'src_x * 2.0'
 
 Common variable types:
 
-- `'SINGLE_PROP'`: read any RNA property. Set `targets[0].id = some_id` and `targets[0].data_path = 'some.path'`.
+- `'SINGLE_PROP'`: read any RNA property. Set `targets[0].id = some_id` and `targets[0].data_path = 'some.path'`. The target id pointer defaults to the `OBJECT` type; to point at a non-object datablock (a Scene, Material, etc.) set `targets[0].id_type` first, e.g. `targets[0].id_type = 'SCENE'`, otherwise the `id =` assignment raises `TypeError`.
 - `'TRANSFORMS'`: read a transform channel. Set `transform_type` (`LOC_X`, `ROT_Y`, `SCALE_Z`, etc.).
 - `'ROTATION_DIFF'`: angle between two bones in radians.
 - `'LOC_DIFF'`: distance between two object locations.
@@ -107,6 +107,7 @@ fcurve.driver.type = 'SCRIPTED'
 var = fcurve.driver.variables.new()
 var.name = 't'
 var.type = 'SINGLE_PROP'
+var.targets[0].id_type = 'SCENE'  # required before assigning a non-Object id
 var.targets[0].id = bpy.context.scene
 var.targets[0].data_path = 'frame_current'
 

--- a/skills/geometry-nodes-python/SKILL.md
+++ b/skills/geometry-nodes-python/SKILL.md
@@ -155,7 +155,8 @@ The argument is the exact RNA `bl_idname` of the node class. A few you'll reach 
 | Mix | `ShaderNodeMix` |
 | Noise Texture | `ShaderNodeTexNoise` |
 | Mesh to SDF Grid (4.3+) | `GeometryNodeMeshToSDFGrid` |
-| SDF Grid to Mesh / Volume to Mesh | `GeometryNodeVolumeToMesh` |
+| Grid to Mesh (meshes an SDF/grid) | `GeometryNodeGridToMesh` |
+| Volume to Mesh (meshes a volume geometry) | `GeometryNodeVolumeToMesh` |
 | Repeat Input / Output | `GeometryNodeRepeatInput`, `GeometryNodeRepeatOutput` |
 | For Each Element Input / Output (4.3+) | `GeometryNodeForeachGeometryElementInput`, `GeometryNodeForeachGeometryElementOutput` |
 
@@ -274,13 +275,19 @@ def has_for_each_element():
 
 6. **Building the tree without group input/output nodes**. The tree's interface sockets only matter once you have `NodeGroupInput` and `NodeGroupOutput` instances connected to actual nodes inside the tree.
 
-## Worked example: replicate the "Mesh to SDF then Volume to Mesh" pipeline
+## Worked example: replicate the "Mesh to SDF then Grid to Mesh" pipeline
+
+An SDF grid is meshed with **Grid to Mesh** (`GeometryNodeGridToMesh`), not **Volume to
+Mesh**. The `Mesh to SDF Grid` output is a *grid* socket; `Volume to Mesh` takes a *volume
+geometry* socket (what `Mesh to Volume` produces), so wiring the SDF grid into it is an
+invalid connection that silently yields no geometry. `Grid to Mesh` has the matching grid
+input. For an SDF the surface is at distance 0, so use `threshold=0.0`.
 
 ```python
 import bpy
 
 
-def build_remesh_via_sdf(voxel_size=0.05, threshold=0.5):
+def build_remesh_via_sdf(voxel_size=0.05, threshold=0.0):
     tree = bpy.data.node_groups.new(name="SDFRemesh", type='GeometryNodeTree')
 
     tree.interface.new_socket(name="Geometry", in_out='INPUT', socket_type='NodeSocketGeometry')
@@ -289,19 +296,19 @@ def build_remesh_via_sdf(voxel_size=0.05, threshold=0.5):
     grp_in = tree.nodes.new('NodeGroupInput')
     grp_out = tree.nodes.new('NodeGroupOutput')
     mesh_to_sdf = tree.nodes.new('GeometryNodeMeshToSDFGrid')
-    volume_to_mesh = tree.nodes.new('GeometryNodeVolumeToMesh')
+    grid_to_mesh = tree.nodes.new('GeometryNodeGridToMesh')
 
     mesh_to_sdf.inputs["Voxel Size"].default_value = voxel_size
-    volume_to_mesh.inputs["Threshold"].default_value = threshold
+    grid_to_mesh.inputs["Threshold"].default_value = threshold  # isosurface at the SDF zero-level
 
     grp_in.location = (-400, 0)
     mesh_to_sdf.location = (-150, 0)
-    volume_to_mesh.location = (150, 0)
+    grid_to_mesh.location = (150, 0)
     grp_out.location = (400, 0)
 
     tree.links.new(grp_in.outputs["Geometry"], mesh_to_sdf.inputs["Mesh"])
-    tree.links.new(mesh_to_sdf.outputs["SDF Grid"], volume_to_mesh.inputs["Volume"])
-    tree.links.new(volume_to_mesh.outputs["Mesh"], grp_out.inputs["Geometry"])
+    tree.links.new(mesh_to_sdf.outputs["SDF Grid"], grid_to_mesh.inputs["Grid"])
+    tree.links.new(grid_to_mesh.outputs["Mesh"], grp_out.inputs["Geometry"])
 
     return tree
 ```


### PR DESCRIPTION
## Summary

Two in-Blender findings from executing the content on 4.5.10 LTS and 5.1.1, both reproduced and both fixes verified on both builds.

### F1 — driver_namespace example raised TypeError (fix)
`skills/drivers-and-app-handlers/SKILL.md`: the worked example did `var.targets[0].id = bpy.context.scene` without first setting `id_type='SCENE'`. A `SINGLE_PROP` target id pointer defaults to `OBJECT`, so the assignment raised `TypeError: DriverTarget.id expected a Object type, not Scene` on **both** versions.

- **Repro (both):** `RAISES: TypeError: ... DriverTarget.id expected a Object type, not Scene`
- **Fix:** add `var.targets[0].id_type = 'SCENE'` before the `id =` line (matching the already-correct snippet `driver-with-custom-function.py` L28); also clarified the `SINGLE_PROP` prose.
- **Post-fix (both):** driver attaches and `location.z` evaluates to `[0.0, 2.425, 4.9985]` across frames 1/50/100.

### F2 — SDF-remesh example produced 0 vertices (diagnosed, then fixed)
`skills/geometry-nodes-python/SKILL.md`: `build_remesh_via_sdf` wired `MeshToSDFGrid` → `VolumeToMesh`.

- **Diagnosis (not a parameter bug):** `MeshToSDFGrid.outputs["SDF Grid"]` is a grid/float socket (`type=VALUE`, `NodeSocketFloat`); `VolumeToMesh.inputs["Volume"]` is `NodeSocketGeometry`. The link is **`is_valid=False`** — incompatible socket types — so VolumeToMesh gets no data and emits **0 verts** at every Voxel Size / Band Width / Threshold combination on both builds. Control: `MeshToVolume → VolumeToMesh` is `is_valid=True` and meshes fine (8216/7778 verts), confirming VolumeToMesh is for *volume geometry*, not bare grids.
- **Correct node:** `GeometryNodeGridToMesh` ("Grid to Mesh") — `IN=['Grid','Threshold','Adaptivity'] OUT=['Mesh']`, `Grid` input type-compatible with the SDF grid output.
- **Fix:** switch to `GridToMesh`, wire `SDF Grid → Grid`, default `threshold=0.0` (SDF zero-level); updated heading + node-reference table.
- **Post-fix (both):** cube remesh yields **10088 verts (5.1.1) / 9602 (4.5.10)**, `zrange (-1.0, 1.0)` (the cube spans ±1).

## Constraints
Counts unchanged (12/6/2/17). No edits to CHANGELOG / CLAUDE `**Version:**` / ROADMAP `**Current:**`. standards-version stays 1.10.0. CLAUDE.md untouched (no context-mode block). Both commits signed (`-s`). Per known release.yml behavior this `fix:` will cut a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)