### PR TITLE
ci: align blender-smoke to actions/checkout@v7

### DIFF
--- a/.github/workflows/blender-smoke.yml
+++ b/.github/workflows/blender-smoke.yml
@@ -32,7 +32,7 @@ jobs:
           - series: "5.1"   # current stable
           - series: "4.5"   # active LTS
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install Blender runtime libraries
         run: |


### PR DESCRIPTION
Dependabot #11 bumped `actions/checkout` 6→7 in the other workflows but predated `blender-smoke.yml`. This bumps it too so all six workflows use `checkout@v7` (no v6/v7 split). CI-only, no shipped content; will squash-merge with `[skip ci]` so no release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)