### PR TITLE
docs: decouple roadmap themes from version pins

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,14 +4,19 @@
 
 **Current:** v0.4.0
 
-| Version | Theme | Skills | Rules | Templates | Snippets | Status |
-| --- | --- | --- | --- | --- | --- | --- |
-| v0.1.0 | Foundation | 8 | 4 | 1 | 10 | Shipped |
-| v0.2.0 | Materials, drivers, migration | 12 | 6 | 2 | 17 | Shipped |
-| v0.3.0 | Examples and demos (smoke-gated) | 12 | 6 | 2 | 17 | Shipped |
-| v0.4.0 | More examples (turntable, SDF remesh) | 12 | 6 | 2 | 17 | Shipped |
-| v0.5.0 | 5.2 LTS sweep, modal operators, USD | TBD | TBD | TBD | TBD | Planned |
-| v1.0.0 | Stable | TBD | TBD | TBD | TBD | Planned |
+Themes are listed in order. Shipped themes note the release they landed in (for reference,
+not a commitment); upcoming themes are intentionally **not** pinned to a version number, so
+shipping another example or skill never forces a roadmap renumber. The release pipeline
+derives the actual version from conventional-commit types.
+
+| Theme | Skills | Rules | Templates | Snippets | Status |
+| --- | --- | --- | --- | --- | --- |
+| Foundation | 8 | 4 | 1 | 10 | Shipped (v0.1.0) |
+| Materials, drivers, migration | 12 | 6 | 2 | 17 | Shipped (v0.2.0) |
+| Examples and demos (smoke-gated) | 12 | 6 | 2 | 17 | Shipped (v0.3.0) |
+| More examples (turntable, SDF remesh) | 12 | 6 | 2 | 17 | Shipped (v0.4.0) |
+| 5.2 LTS sweep, modal operators, USD | — | — | — | — | Upcoming |
+| Stable | — | — | — | — | Upcoming |
 
 ## v0.1.0 - Foundation
 
@@ -80,7 +85,7 @@ The 7 new snippets:
 
 Audit pass on v0.1.0 content: standards-version markers bumped from `1.9.1` to `1.9.4` across all skills, rules, AGENTS.md, CLAUDE.md, and ROADMAP.md. Verified the `bpy_extras.anim_utils.action_ensure_channelbag_for_slot` import path against the current Blender 5.1 API reference and removed the stale "verify before production" caveat in `slotted-actions-animation/SKILL.md`.
 
-## v0.5.0 (candidate pool)
+## Candidate pool (next content)
 
 Not committed; target list for the next content version. (v0.3.0 shipped the smoke-gated `examples/` track.)
 


### PR DESCRIPTION
## Phase 1 of 5 — roadmap decoupling

Every example promotion is a `feat:` (minor bump), and the ROADMAP pinned themes to exact versions — forcing a renumber each time (this would have been the 3rd). This converts the version-theme table to a **theme-ordered** table with **no hard version pins on upcoming rows**:

- Shipped themes note their release in Status (`Shipped (v0.x.0)`) — reference, not a pin.
- Upcoming themes (5.2 sweep, Stable) carry **no** version → shipping another example/skill never forces a renumber again.
- Candidate-pool heading de-pinned (`## Candidate pool (next content)`).
- `**Current:**` line untouched (release-doc-sync owns it).

`docs:`-only → under the gate it must cut **no** release. Merging via normal squash (no `[skip ci]`); will confirm the push-triggered release.yml logged SKIP and VERSION stayed 0.4.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)