### PR TITLE
docs: per-example detail pages in the gallery

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,7 +17,7 @@ on:
       - "site.json"
       - ".cursor-plugin/plugin.json"
       - "assets/**"
-      - "examples/gallery.json"
+      - "examples/**"
       - "docs/gallery/**"
       - "scripts/build_gallery.py"
       - "scripts/site/**"

--- a/docs/gallery/depsgraph-export/index.html
+++ b/docs/gallery/depsgraph-export/index.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Examples Gallery — Blender Developer Tools</title>
-  <meta name="description" content="Runnable, smoke-gated Blender Python examples — each executed headless on Blender 4.5 LTS and 5.1, so every render reflects code that actually runs." />
-  <link rel="canonical" href="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/" />
-  <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml" />
+  <title>depsgraph-export — Examples — Blender Developer Tools</title>
+  <meta name="description" content="The depsgraph lifetime contract — evaluated_get().to_mesh() paired with to_mesh_clear() — measured against an OBJ export of the same object." />
+  <link rel="canonical" href="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/depsgraph-export/" />
+  <link rel="icon" href="../../assets/favicon.svg" type="image/svg+xml" />
   <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)" />
   <meta name="theme-color" content="#f6f8fa" media="(prefers-color-scheme: light)" />
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="Examples Gallery — Blender Developer Tools" />
-  <meta property="og:description" content="Runnable, smoke-gated Blender Python examples — each executed headless on Blender 4.5 LTS and 5.1, so every render reflects code that actually runs." />
-  <meta property="og:url" content="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/" />
-  <meta property="og:image" content="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/assets/swatch-grid-hero.webp" />
+  <meta property="og:title" content="depsgraph-export — Examples — Blender Developer Tools" />
+  <meta property="og:description" content="The depsgraph lifetime contract — evaluated_get().to_mesh() paired with to_mesh_clear() — measured against an OBJ export of the same object." />
+  <meta property="og:url" content="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/depsgraph-export/" />
+  <meta property="og:image" content="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/assets/depsgraph-export-hero.webp" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Examples Gallery — Blender Developer Tools" />
-  <meta name="twitter:description" content="Runnable, smoke-gated Blender Python examples — each executed headless on Blender 4.5 LTS and 5.1, so every render reflects code that actually runs." />
-  <meta name="twitter:image" content="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/assets/swatch-grid-hero.webp" />
+  <meta name="twitter:title" content="depsgraph-export — Examples — Blender Developer Tools" />
+  <meta name="twitter:description" content="The depsgraph lifetime contract — evaluated_get().to_mesh() paired with to_mesh_clear() — measured against an OBJ export of the same object." />
+  <meta name="twitter:image" content="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/assets/depsgraph-export-hero.webp" />
   <!-- FOUC guard: apply the saved theme before first paint. Shares the 'theme'
        key with the landing page, so a visitor's choice carries across. -->
   <script>(function(){try{var t=localStorage.getItem('theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
@@ -165,73 +165,103 @@
 <body>
   <a class="skip" href="#main">Skip to content</a>
   <div class="topbar">
-    <a class="back" href="../"><span aria-hidden="true">&larr;</span> Blender Developer Tools</a>
+    <a class="back" href="../"><span aria-hidden="true">&larr;</span> Examples Gallery</a>
     <div class="topbar-right">
       <a class="ghlink" href="https://github.com/TMHSDigital/Blender-Developer-Tools">GitHub</a>
       <button class="theme-toggle" id="themeToggle" type="button" aria-label="Theme: auto (click to change)">&#9788;</button>
     </div>
   </div>
   <header class="hero">
-    <h1>Examples Gallery</h1>
-    <p>Runnable, smoke-gated Blender Python examples — each executed headless on Blender 4.5 LTS and 5.1, so every render reflects code that actually runs.</p>
+    <h1>depsgraph-export</h1>
+    <p>The depsgraph lifetime contract — evaluated_get().to_mesh() paired with to_mesh_clear() — measured against an OBJ export of the same object.</p>
   </header>
-  <div class="chips" role="toolbar" aria-label="Filter examples by topic">
-    <button class="chip active" data-tag="" type="button">All</button>
-    <button class="chip" data-tag="animation" type="button">animation</button>
-    <button class="chip" data-tag="depsgraph" type="button">depsgraph</button>
-    <button class="chip" data-tag="export" type="button">export</button>
-    <button class="chip" data-tag="geometry-nodes" type="button">geometry-nodes</button>
-    <button class="chip" data-tag="materials" type="button">materials</button>
-    <button class="chip" data-tag="rendering" type="button">rendering</button>
-  </div>
   <main id="main">
-    <div class="grid">
-      <article class="card" data-tags="materials rendering">
-        <a class="card-media" href="swatch-grid/" aria-label="swatch-grid example detail page">
-          <img src="assets/swatch-grid-hero.webp" alt="swatch-grid — Procedural Principled materials — metal and dielectric, the emission pattern, and the cross-version set_specular shim" loading="lazy" decoding="async" />
-        </a>
-        <div class="card-body">
-          <h2><a href="swatch-grid/">swatch-grid</a></h2>
-          <p class="teaches">Procedural Principled materials — metal and dielectric, the emission pattern, and the cross-version set_specular shim.</p>
-          <p class="witnesses"><span class="tag">witnesses</span> EEVEE engine-id mapping: BLENDER_EEVEE on 5.x, BLENDER_EEVEE_NEXT on 4.2–4.5.</p>
-          <a class="card-link" href="swatch-grid/">View example <span aria-hidden="true">&rarr;</span></a>
-        </div>
-      </article>
-      <article class="card" data-tags="animation">
-        <a class="card-media" href="turntable/" aria-label="turntable example detail page">
-          <img src="assets/turntable-hero.webp" alt="turntable — A slotted-actions Z-rotation turntable keyed through the cross-version channelbag path (get_channelbag_for_slot)" loading="lazy" decoding="async" />
-        </a>
-        <div class="card-body">
-          <h2><a href="turntable/">turntable</a></h2>
-          <p class="teaches">A slotted-actions Z-rotation turntable keyed through the cross-version channelbag path (get_channelbag_for_slot).</p>
-          <p class="witnesses"><span class="tag">witnesses</span> Slotted-actions boundary: ensure-helper channelbag on 5.x, strip.channelbag on 4.4/4.5.</p>
-          <a class="card-link" href="turntable/">View example <span aria-hidden="true">&rarr;</span></a>
-        </div>
-      </article>
-      <article class="card" data-tags="geometry-nodes materials">
-        <a class="card-media" href="gn-sdf-remesh/" aria-label="gn-sdf-remesh example detail page">
-          <img src="assets/gn-sdf-remesh-hero.webp" alt="gn-sdf-remesh — A Geometry Nodes SDF remesh (MeshToSDFGrid → GridToMesh at the SDF zero-level), with a Set Material node carrying the material through the remesh" loading="lazy" decoding="async" />
-        </a>
-        <div class="card-body">
-          <h2><a href="gn-sdf-remesh/">gn-sdf-remesh</a></h2>
-          <p class="teaches">A Geometry Nodes SDF remesh (MeshToSDFGrid → GridToMesh at the SDF zero-level), with a Set Material node carrying the material through the remesh.</p>
-          <p class="witnesses"><span class="tag">witnesses</span> An SDF grid is meshed with Grid to Mesh, not Volume to Mesh; GN geometry needs Set Material or it renders untextured.</p>
-          <a class="card-link" href="gn-sdf-remesh/">View example <span aria-hidden="true">&rarr;</span></a>
-        </div>
-      </article>
-      <article class="card" data-tags="depsgraph export">
-        <a class="card-media" href="depsgraph-export/" aria-label="depsgraph-export example detail page">
-          <img src="assets/depsgraph-export-hero.webp" alt="depsgraph-export — The depsgraph lifetime contract — evaluated_get()" loading="lazy" decoding="async" />
-        </a>
-        <div class="card-body">
-          <h2><a href="depsgraph-export/">depsgraph-export</a></h2>
-          <p class="teaches">The depsgraph lifetime contract — evaluated_get().to_mesh() paired with to_mesh_clear() — measured against an OBJ export of the same object.</p>
-          <p class="witnesses"><span class="tag">witnesses</span> Exports ship evaluated geometry: the exported vertex count equals the subsurf-applied count and is strictly greater than the base mesh.</p>
-          <a class="card-link" href="depsgraph-export/">View example <span aria-hidden="true">&rarr;</span></a>
-        </div>
-      </article>
+    <button class="detail-hero" id="heroZoom" type="button" aria-label="Zoom depsgraph-export render">
+      <img src="../assets/depsgraph-export-hero.webp" alt="depsgraph-export render" width="1280" height="720" />
+    </button>
+    <p class="zoom-hint">Rendered headless by the example itself — click to zoom.</p>
+    <div class="callout"><span class="tag">witnesses</span> Exports ship evaluated geometry: the exported vertex count equals the subsurf-applied count and is strictly greater than the base mesh.</div>
+    <div class="runline">
+      <pre id="runCmd">blender --background --python examples/depsgraph-export/depsgraph_export.py --</pre>
+      <button class="copy-btn" id="copyRun" type="button">Copy</button>
     </div>
+    <section class="detail-section md">
+<p>A runnable example that proves <strong>modifiers actually ship in exports</strong> and demonstrates the <a href="https://github.com/TMHSDigital/Blender-Developer-Tools/tree/main/skills/depsgraph-and-evaluated-data/SKILL.md"><code>depsgraph-and-evaluated-data</code></a> lifetime contract. It builds a cube with a SUBSURF modifier, measures the evaluated mesh via <code>evaluated_get().to_mesh()</code> (paired with <code>to_mesh_clear()</code>), exports through <code>wm.obj_export</code>, and asserts the exported vertex count equals the <strong>evaluated</strong> (modifier-applied) count and is strictly greater than the base mesh.</p>
+<p><strong>What it witnesses:</strong> the <code>evaluated_get</code> → <code>to_mesh</code> → <code>to_mesh_clear</code> contract, and that <code>wm.obj_export</code> writes the depsgraph-evaluated geometry (so modifiers are baked into the export) rather than the unmodified base mesh.</p>
+<h2>Run</h2>
+<pre><code># Cheap correctness check (writes an OBJ to a temp path, asserts the counts) — the CI check:
+blender --background --python depsgraph_export.py --
+
+# Write the exported OBJ to a specific path:
+blender --background --python depsgraph_export.py -- --output remeshed.obj</code></pre>
+<p>It exits non-zero on failure (modifier not applied, or exported count ≠ evaluated count). The <code>blender-smoke</code> workflow runs this check on Blender 4.5 LTS and 5.1: base 8 → evaluated/exported 98 vertices with a 2-level SUBSURF.</p>
+    </section>
+    <section class="detail-section src">
+      <h2>Source</h2>
+      <div class="src-meta">
+        <code>examples/depsgraph-export/depsgraph_export.py</code>
+        <a href="https://github.com/TMHSDigital/Blender-Developer-Tools/tree/main/examples/depsgraph-export/depsgraph_export.py">View on GitHub &rarr;</a>
+      </div>
+      <pre><span class="s">&quot;&quot;&quot;Candidate B: depsgraph-evaluated export (SCRATCH).
+
+Witnesses the depsgraph lifetime contract AND that modifiers actually ship in exports. Builds
+a cube with a SUBSURF modifier, measures the evaluated mesh via evaluated_get().to_mesh()
+(paired with to_mesh_clear()), exports through wm.obj_export, and asserts the exported vertex
+count equals the EVALUATED (modifier-applied) count and is strictly greater than the base.
+&quot;&quot;&quot;</span>
+<span class="k">import</span> bpy, bmesh, sys, os, argparse
+
+<span class="k">def</span> main():
+    argv = sys.argv[sys.argv.index(<span class="s">&quot;--&quot;</span>) + <span class="n">1</span>:] <span class="k">if</span> <span class="s">&quot;--&quot;</span> <span class="k">in</span> sys.argv <span class="k">else</span> []
+    p = argparse.ArgumentParser()
+    p.add_argument(<span class="s">&quot;--output&quot;</span>, default=<span class="k">None</span>, help=<span class="s">&quot;optional: write the exported OBJ here (else a temp path)&quot;</span>)
+    args = p.parse_args(argv)
+
+    bpy.ops.wm.read_factory_settings(use_empty=<span class="k">True</span>)
+    me = bpy.data.meshes.new(<span class="s">&quot;Cube&quot;</span>); bm = bmesh.new(); bmesh.ops.create_cube(bm, size=<span class="n">2.0</span>); bm.to_mesh(me); bm.free()
+    obj = bpy.data.objects.new(<span class="s">&quot;Cube&quot;</span>, me); bpy.context.collection.objects.link(obj)
+    obj.modifiers.new(<span class="s">&quot;ss&quot;</span>, <span class="s">&#x27;SUBSURF&#x27;</span>).levels = <span class="n">2</span>
+    base = len(obj.data.vertices)
+
+    <span class="c"># depsgraph lifetime contract: evaluate, read, then release with to_mesh_clear</span>
+    dg = bpy.context.evaluated_depsgraph_get()
+    ev = obj.evaluated_get(dg)
+    em = ev.to_mesh()
+    eval_vcount = len(em.vertices)
+    ev.to_mesh_clear()  <span class="c"># must be paired; releases the temporary mesh</span>
+
+    <span class="k">import</span> tempfile
+    out = args.output <span class="k">or</span> os.path.join(tempfile.gettempdir(), <span class="s">&quot;depsgraph_export.obj&quot;</span>)
+    os.makedirs(os.path.dirname(os.path.abspath(out)) <span class="k">or</span> <span class="s">&quot;.&quot;</span>, exist_ok=<span class="k">True</span>)
+    <span class="c"># obj_export writes the evaluated (modifier-applied) geometry by default</span>
+    bpy.ops.wm.obj_export(filepath=out, export_selected_objects=<span class="k">False</span>)
+    <span class="k">if</span> <span class="k">not</span> (os.path.exists(out) <span class="k">and</span> os.path.getsize(out) &gt; <span class="n">0</span>):
+        print(<span class="s">&quot;ERROR: no OBJ written&quot;</span>, file=sys.stderr); <span class="k">return</span> <span class="n">4</span>
+    exported = <span class="n">0</span>
+    <span class="k">with</span> open(out) <span class="k">as</span> f:
+        <span class="k">for</span> line <span class="k">in</span> f:
+            <span class="k">if</span> line.startswith(<span class="s">&quot;v &quot;</span>): exported += <span class="n">1</span>
+
+    print(<span class="s">f&quot;</span><span class="s">base_vcount=</span>{base}<span class="s"> eval_vcount=</span>{eval_vcount}<span class="s"> exported_vcount=</span>{exported}<span class="s">&quot;</span>)
+    <span class="k">if</span> <span class="k">not</span> (eval_vcount &gt; base):
+        print(<span class="s">&quot;ERROR: evaluated mesh did not apply the modifier&quot;</span>, file=sys.stderr); <span class="k">return</span> <span class="n">3</span>
+    <span class="k">if</span> exported != eval_vcount:
+        print(<span class="s">f&quot;</span><span class="s">ERROR: export (</span>{exported}<span class="s">) != evaluated (</span>{eval_vcount}<span class="s">); modifier did not ship</span><span class="s">&quot;</span>,
+              file=sys.stderr); <span class="k">return</span> <span class="n">5</span>
+    print(<span class="s">&quot;depsgraph-export OK&quot;</span>)
+    <span class="k">return</span> <span class="n">0</span>
+
+<span class="k">if</span> __name__ == <span class="s">&quot;__main__&quot;</span>:
+    <span class="k">try</span>:
+        sys.exit(main())
+    <span class="k">except</span> Exception <span class="k">as</span> e:
+        <span class="k">import</span> traceback; traceback.print_exc(); print(<span class="s">f&quot;</span><span class="s">FATAL: </span>{e}<span class="s">&quot;</span>, file=sys.stderr); sys.exit(<span class="n">1</span>)
+</pre>
+    </section>
   </main>
+  <div class="lightbox" id="lightbox" role="dialog" aria-label="Full-size render">
+    <img src="../assets/depsgraph-export-hero.webp" alt="depsgraph-export render, full size" />
+  </div>
   <footer>
     Generated from <code>examples/gallery.json</code> by <code>scripts/build_gallery.py</code>.
     &nbsp;&bull;&nbsp; CC-BY-NC-ND-4.0
@@ -257,19 +287,25 @@
     })();
 
     (function () {
-      var chips = document.querySelectorAll('.chip');
-      var cards = document.querySelectorAll('.card');
-      chips.forEach(function (chip) {
-        chip.addEventListener('click', function () {
-          chips.forEach(function (c) { c.classList.remove('active'); });
-          chip.classList.add('active');
-          var tag = chip.getAttribute('data-tag');
-          cards.forEach(function (card) {
-            var tags = (card.getAttribute('data-tags') || '').split(' ');
-            card.classList.toggle('hidden', !!tag && tags.indexOf(tag) === -1);
+      var hero = document.getElementById('heroZoom');
+      var box = document.getElementById('lightbox');
+      if (hero && box) {
+        hero.addEventListener('click', function () { box.classList.add('open'); });
+        box.addEventListener('click', function () { box.classList.remove('open'); });
+        document.addEventListener('keydown', function (e) {
+          if (e.key === 'Escape') box.classList.remove('open');
+        });
+      }
+      var copy = document.getElementById('copyRun');
+      if (copy) {
+        copy.addEventListener('click', function () {
+          var cmd = document.getElementById('runCmd').textContent;
+          navigator.clipboard.writeText(cmd).then(function () {
+            copy.textContent = 'Copied!';
+            setTimeout(function () { copy.textContent = 'Copy'; }, 1500);
           });
         });
-      });
+      }
     })();
 
   </script>

--- a/docs/gallery/gn-sdf-remesh/index.html
+++ b/docs/gallery/gn-sdf-remesh/index.html
@@ -1,0 +1,387 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>gn-sdf-remesh — Examples — Blender Developer Tools</title>
+  <meta name="description" content="A Geometry Nodes SDF remesh (MeshToSDFGrid → GridToMesh at the SDF zero-level), with a Set Material node carrying the material through the remesh." />
+  <link rel="canonical" href="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/gn-sdf-remesh/" />
+  <link rel="icon" href="../../assets/favicon.svg" type="image/svg+xml" />
+  <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)" />
+  <meta name="theme-color" content="#f6f8fa" media="(prefers-color-scheme: light)" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="gn-sdf-remesh — Examples — Blender Developer Tools" />
+  <meta property="og:description" content="A Geometry Nodes SDF remesh (MeshToSDFGrid → GridToMesh at the SDF zero-level), with a Set Material node carrying the material through the remesh." />
+  <meta property="og:url" content="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/gn-sdf-remesh/" />
+  <meta property="og:image" content="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/assets/gn-sdf-remesh-hero.webp" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="gn-sdf-remesh — Examples — Blender Developer Tools" />
+  <meta name="twitter:description" content="A Geometry Nodes SDF remesh (MeshToSDFGrid → GridToMesh at the SDF zero-level), with a Set Material node carrying the material through the remesh." />
+  <meta name="twitter:image" content="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/assets/gn-sdf-remesh-hero.webp" />
+  <!-- FOUC guard: apply the saved theme before first paint. Shares the 'theme'
+       key with the landing page, so a visitor's choice carries across. -->
+  <script>(function(){try{var t=localStorage.getItem('theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <style>
+    :root {
+      --bg: #0d1117; --bg2: #161b22; --surface: #161b22; --surface-2: #1c2128;
+      --border: #30363d; --text: #e6edf3; --text-dim: #8b949e;
+      --accent: #7c3aed; --accent-light: #a78bfa;
+      --radius: 8px; --radius-lg: 12px; --maxw: 1080px;
+      --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      --font-mono: ui-monospace, 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
+      --code-k: #ff7b72; --code-s: #a5d6ff; --code-c: #8b949e; --code-n: #79c0ff;
+    }
+    /* auto mode: follow the OS unless the user forced dark */
+    @media (prefers-color-scheme: light) {
+      :root:not([data-theme="dark"]) {
+        --bg: #f6f8fa; --bg2: #ffffff; --surface: #ffffff; --surface-2: #f0f2f5;
+        --border: #d0d7de; --text: #1f2328; --text-dim: #656d76;
+        --code-k: #cf222e; --code-s: #0a3069; --code-c: #6e7781; --code-n: #0550ae;
+      }
+    }
+    /* explicit override */
+    [data-theme="light"] {
+      --bg: #f6f8fa; --bg2: #ffffff; --surface: #ffffff; --surface-2: #f0f2f5;
+      --border: #d0d7de; --text: #1f2328; --text-dim: #656d76;
+      --code-k: #cf222e; --code-s: #0a3069; --code-c: #6e7781; --code-n: #0550ae;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body { font-family: var(--font-sans); background: var(--bg); color: var(--text);
+      line-height: 1.6; min-height: 100vh; -webkit-font-smoothing: antialiased; }
+    a { color: var(--accent-light); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    :focus-visible { outline: 2px solid var(--accent-light); outline-offset: 2px; border-radius: 3px; }
+    .skip { position: absolute; left: -999px; top: 0; background: var(--accent); color: #fff;
+      padding: 0.5rem 1rem; border-radius: var(--radius); z-index: 10; }
+    .skip:focus { left: 0.5rem; top: 0.5rem; }
+
+    .topbar { position: sticky; top: 0; z-index: 5; display: flex; align-items: center;
+      justify-content: space-between; gap: 1rem; padding: 0.75rem 1.25rem;
+      background: color-mix(in srgb, var(--bg) 88%, transparent);
+      backdrop-filter: blur(10px); border-bottom: 1px solid var(--border); }
+    .topbar .back { color: var(--text-dim); font-size: 0.9rem; font-weight: 500; }
+    .topbar .back:hover { color: var(--accent-light); }
+    .topbar-right { display: flex; align-items: center; gap: 0.85rem; }
+    .topbar-right .ghlink { color: var(--text-dim); font-size: 0.9rem; font-weight: 500; }
+    .topbar-right .ghlink:hover { color: var(--accent-light); }
+    .theme-toggle { background: var(--surface-2); border: 1px solid var(--border);
+      color: var(--text); border-radius: var(--radius); padding: 0.35rem 0.6rem;
+      font-size: 0.95rem; cursor: pointer; line-height: 1; transition: border-color 0.15s, background 0.15s; }
+    .theme-toggle:hover { border-color: var(--accent-light); }
+
+    header.hero { max-width: var(--maxw); margin: 0 auto; padding: 3rem 1.25rem 1.5rem; }
+    header.hero h1 { font-size: clamp(1.9rem, 4vw, 2.6rem); letter-spacing: -0.02em; line-height: 1.15; }
+    header.hero p { color: var(--text-dim); max-width: 62ch; margin-top: 0.6rem; font-size: 1.02rem; }
+
+    /* ---- index: filter chips ---- */
+    .chips { max-width: var(--maxw); margin: 0 auto; padding: 0 1.25rem 0.25rem;
+      display: flex; flex-wrap: wrap; gap: 0.5rem; }
+    .chip { background: var(--surface-2); border: 1px solid var(--border); color: var(--text-dim);
+      border-radius: 999px; padding: 0.25rem 0.85rem; font-size: 0.82rem; font-weight: 500;
+      font-family: var(--font-sans); cursor: pointer; transition: color 0.15s, border-color 0.15s; }
+    .chip:hover { color: var(--accent-light); border-color: var(--accent); }
+    .chip.active { color: #fff; background: var(--accent); border-color: var(--accent); }
+
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem 1.25rem 2rem; }
+    .grid { display: grid; grid-template-columns: 1fr; gap: 1.5rem; align-items: stretch; }
+    .card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg);
+      overflow: hidden; display: flex; flex-direction: column;
+      transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease; }
+    .card:hover { transform: translateY(-3px); border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+      box-shadow: 0 8px 28px rgba(0,0,0,0.28); }
+    .card.hidden { display: none; }
+    .card-media { display: block; background: var(--bg2); line-height: 0; }
+    .card-media img { display: block; width: 100%; aspect-ratio: 16 / 9; object-fit: cover; }
+    .card-body { padding: 1.15rem 1.4rem 1.45rem; display: flex; flex-direction: column; flex: 1 1 auto; }
+    .card-body h2 { font-size: 1.22rem; letter-spacing: -0.01em; margin-bottom: 0.5rem; }
+    .card-body h2 a { color: var(--text); }
+    .card-body h2 a:hover { color: var(--accent-light); text-decoration: none; }
+    .teaches { color: var(--text); margin-bottom: 0.7rem; }
+    .witnesses { color: var(--text-dim); font-size: 0.9rem; margin-bottom: 1rem; }
+    .tag { display: inline-block; font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.06em;
+      color: var(--accent-light); border: 1px solid color-mix(in srgb, var(--accent) 60%, transparent);
+      border-radius: 999px; padding: 0.08rem 0.55rem; margin-right: 0.4rem; vertical-align: 1px; }
+    .card-link { font-weight: 600; font-size: 0.95rem; margin-top: auto; }
+
+    /* ---- detail page ---- */
+    .detail-hero { border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden;
+      background: var(--bg2); padding: 0; display: block; width: 100%; cursor: zoom-in; line-height: 0; }
+    .detail-hero img { display: block; width: 100%; aspect-ratio: 16 / 9; object-fit: cover; }
+    .zoom-hint { color: var(--text-dim); font-size: 0.78rem; margin-top: 0.4rem; }
+    .callout { border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
+      border-left: 3px solid var(--accent); border-radius: var(--radius);
+      background: color-mix(in srgb, var(--accent) 7%, var(--surface));
+      padding: 0.85rem 1.1rem; margin: 1.5rem 0; font-size: 0.95rem; }
+    .runline { display: flex; align-items: stretch; gap: 0.5rem; margin: 1.5rem 0; }
+    .runline pre { flex: 1 1 auto; background: var(--surface-2); border: 1px solid var(--border);
+      border-radius: var(--radius); padding: 0.7rem 0.9rem; overflow-x: auto;
+      font-family: var(--font-mono); font-size: 0.83rem; line-height: 1.5; }
+    .copy-btn { flex: 0 0 auto; background: var(--surface-2); border: 1px solid var(--border);
+      color: var(--text-dim); border-radius: var(--radius); padding: 0 0.85rem; cursor: pointer;
+      font-family: var(--font-sans); font-size: 0.82rem; font-weight: 500; transition: color 0.15s, border-color 0.15s; }
+    .copy-btn:hover { color: var(--accent-light); border-color: var(--accent); }
+    .detail-section { margin-top: 2.25rem; }
+    .detail-section > h2 { font-size: 1.15rem; letter-spacing: -0.01em; padding-bottom: 0.5rem;
+      border-bottom: 1px solid var(--border); margin-bottom: 1rem; }
+
+    .md h1, .md h2, .md h3 { letter-spacing: -0.01em; margin: 1.4rem 0 0.6rem; line-height: 1.25; }
+    .md h1 { font-size: 1.35rem; } .md h2 { font-size: 1.15rem; } .md h3 { font-size: 1rem; }
+    .md p { margin: 0.7rem 0; }
+    .md ul { margin: 0.7rem 0 0.7rem 1.4rem; }
+    .md li { margin: 0.3rem 0; }
+    .md code { background: var(--surface-2); border: 1px solid var(--border); padding: 0.08rem 0.35rem;
+      border-radius: 4px; font-family: var(--font-mono); font-size: 0.84em; }
+    .md pre { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius);
+      padding: 0.85rem 1rem; overflow-x: auto; margin: 0.9rem 0; }
+    .md pre code { background: none; border: none; padding: 0; font-size: 0.83rem; line-height: 1.55; }
+
+    .src pre { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius);
+      padding: 1rem 1.1rem; overflow-x: auto; font-family: var(--font-mono);
+      font-size: 0.82rem; line-height: 1.55; }
+    .src .k { color: var(--code-k); } .src .s { color: var(--code-s); }
+    .src .c { color: var(--code-c); font-style: italic; } .src .n { color: var(--code-n); }
+    .src-meta { display: flex; justify-content: space-between; align-items: baseline; gap: 1rem;
+      flex-wrap: wrap; margin-bottom: 0.6rem; color: var(--text-dim); font-size: 0.85rem; }
+    .src-meta code { font-family: var(--font-mono); font-size: 0.82rem; }
+
+    .lightbox { position: fixed; inset: 0; z-index: 50; display: none; align-items: center;
+      justify-content: center; background: rgba(0,0,0,0.85); padding: 2rem; cursor: zoom-out; }
+    .lightbox.open { display: flex; }
+    .lightbox img { max-width: 100%; max-height: 100%; border-radius: var(--radius); }
+
+    footer { max-width: var(--maxw); margin: 0 auto; padding: 2rem 1.25rem 3rem;
+      color: var(--text-dim); font-size: 0.85rem; border-top: 1px solid var(--border); }
+    footer code { background: var(--surface-2); padding: 0.1rem 0.35rem; border-radius: 4px; font-size: 0.82rem; }
+
+    @media (min-width: 720px) { .grid { grid-template-columns: 1fr 1fr; gap: 1.75rem; } }
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+      .card, .theme-toggle { transition: none; }
+      .card:hover { transform: none; }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip" href="#main">Skip to content</a>
+  <div class="topbar">
+    <a class="back" href="../"><span aria-hidden="true">&larr;</span> Examples Gallery</a>
+    <div class="topbar-right">
+      <a class="ghlink" href="https://github.com/TMHSDigital/Blender-Developer-Tools">GitHub</a>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Theme: auto (click to change)">&#9788;</button>
+    </div>
+  </div>
+  <header class="hero">
+    <h1>gn-sdf-remesh</h1>
+    <p>A Geometry Nodes SDF remesh (MeshToSDFGrid → GridToMesh at the SDF zero-level), with a Set Material node carrying the material through the remesh.</p>
+  </header>
+  <main id="main">
+    <button class="detail-hero" id="heroZoom" type="button" aria-label="Zoom gn-sdf-remesh render">
+      <img src="../assets/gn-sdf-remesh-hero.webp" alt="gn-sdf-remesh render" width="1280" height="720" />
+    </button>
+    <p class="zoom-hint">Rendered headless by the example itself — click to zoom.</p>
+    <div class="callout"><span class="tag">witnesses</span> An SDF grid is meshed with Grid to Mesh, not Volume to Mesh; GN geometry needs Set Material or it renders untextured.</div>
+    <div class="runline">
+      <pre id="runCmd">blender --background --python examples/gn-sdf-remesh/gn_sdf_remesh.py --</pre>
+      <button class="copy-btn" id="copyRun" type="button">Copy</button>
+    </div>
+    <section class="detail-section md">
+<p>A runnable example that remeshes an input mesh through an OpenVDB SDF grid using the <code>build_remesh_via_sdf</code> pattern from the <a href="https://github.com/TMHSDigital/Blender-Developer-Tools/tree/main/skills/geometry-nodes-python/SKILL.md"><code>geometry-nodes-python</code></a> skill: <code>GeometryNodeMeshToSDFGrid</code> → <code>GeometryNodeGridToMesh</code> at the SDF zero-level, attached as a NODES modifier and evaluated via the depsgraph.</p>
+<p><strong>Which fix it witnesses:</strong> an SDF grid is meshed with <strong>Grid to Mesh</strong>, not Volume to Mesh (the <code>Mesh to SDF Grid</code> output is a grid socket; <code>Volume to Mesh</code> takes a volume-geometry socket, so wiring the grid there is an invalid link that yields no geometry). <code>Grid to Mesh</code> has the matching grid input.</p>
+<p><strong>Materials gotcha:</strong> geometry generated by Geometry Nodes carries <strong>no</strong> material, so the input mesh&#x27;s material is dropped on remesh (the result renders with the default white). Re-apply it inside the tree with a <strong>Set Material</strong> node (<code>GeometryNodeSetMaterial</code>) on the remeshed output — this example does that and asserts the material survives onto the evaluated mesh.</p>
+<h2>Run</h2>
+<pre><code># Cheap correctness check only (no render) — the CI smoke check:
+blender --background --python gn_sdf_remesh.py --
+
+# Also render the remeshed result (EEVEE on a GPU host; --engine cycles on GPU-less hosts):
+blender --background --python gn_sdf_remesh.py -- --output remesh.png
+blender --background --python gn_sdf_remesh.py -- --output remesh.png --engine cycles</code></pre>
+<p>By default it runs only the <strong>frame-independent correctness check</strong>: the depsgraph-evaluated vertex count must be &gt; 0 AND differ from the base mesh (the remesh produced geometry). It exits non-zero on failure — the same check the <code>blender-smoke</code> workflow runs on Blender 4.5 LTS and 5.1.</p>
+    </section>
+    <section class="detail-section src">
+      <h2>Source</h2>
+      <div class="src-meta">
+        <code>examples/gn-sdf-remesh/gn_sdf_remesh.py</code>
+        <a href="https://github.com/TMHSDigital/Blender-Developer-Tools/tree/main/examples/gn-sdf-remesh/gn_sdf_remesh.py">View on GitHub &rarr;</a>
+      </div>
+      <pre><span class="s">&quot;&quot;&quot;Geometry Nodes SDF remesh -- a runnable BDT example.
+
+Builds the `build_remesh_via_sdf` pattern from the geometry-nodes-python skill
+(`GeometryNodeMeshToSDFGrid` -&gt; `GeometryNodeGridToMesh` at the SDF zero-level), attaches it
+as a NODES modifier to an input mesh, and evaluates via the depsgraph. It witnesses the F2
+fix: an SDF grid is meshed with **Grid to Mesh**, not Volume to Mesh.
+
+By default it runs only the cheap, frame-independent correctness check (no render): the
+evaluated vertex count must be &gt; 0 AND differ from the base mesh -- proving the remesh
+produced geometry. Exits non-zero on failure. This is the check the CI smoke gate runs on
+both builds.
+
+    blender --background --python gn_sdf_remesh.py --                  # correctness check only
+    blender --background --python gn_sdf_remesh.py -- --output r.png   # also render the result
+    blender --background --python gn_sdf_remesh.py -- --output r.png --engine cycles  # GPU-less
+&quot;&quot;&quot;</span>
+<span class="k">import</span> bpy, sys, os, argparse
+
+<span class="k">def</span> get_eevee_engine_id():
+    <span class="k">return</span> <span class="s">&#x27;BLENDER_EEVEE&#x27;</span> <span class="k">if</span> bpy.app.version &gt;= (<span class="n">5</span>, <span class="n">0</span>, <span class="n">0</span>) <span class="k">else</span> <span class="s">&#x27;BLENDER_EEVEE_NEXT&#x27;</span>
+
+<span class="k">def</span> build_remesh_via_sdf(voxel_size=<span class="n">0.1</span>, threshold=<span class="n">0.0</span>, material=<span class="k">None</span>):
+    tree = bpy.data.node_groups.new(<span class="s">&quot;SDFRemesh&quot;</span>, <span class="s">&#x27;GeometryNodeTree&#x27;</span>)
+    tree.interface.new_socket(name=<span class="s">&quot;Geometry&quot;</span>, in_out=<span class="s">&#x27;INPUT&#x27;</span>, socket_type=<span class="s">&#x27;NodeSocketGeometry&#x27;</span>)
+    tree.interface.new_socket(name=<span class="s">&quot;Geometry&quot;</span>, in_out=<span class="s">&#x27;OUTPUT&#x27;</span>, socket_type=<span class="s">&#x27;NodeSocketGeometry&#x27;</span>)
+    gi = tree.nodes.new(<span class="s">&#x27;NodeGroupInput&#x27;</span>); go = tree.nodes.new(<span class="s">&#x27;NodeGroupOutput&#x27;</span>)
+    mesh_to_sdf = tree.nodes.new(<span class="s">&#x27;GeometryNodeMeshToSDFGrid&#x27;</span>)
+    grid_to_mesh = tree.nodes.new(<span class="s">&#x27;GeometryNodeGridToMesh&#x27;</span>)
+    mesh_to_sdf.inputs[<span class="s">&quot;Voxel Size&quot;</span>].default_value = voxel_size
+    grid_to_mesh.inputs[<span class="s">&quot;Threshold&quot;</span>].default_value = threshold
+    tree.links.new(gi.outputs[<span class="s">&quot;Geometry&quot;</span>], mesh_to_sdf.inputs[<span class="s">&quot;Mesh&quot;</span>])
+    link = tree.links.new(mesh_to_sdf.outputs[<span class="s">&quot;SDF Grid&quot;</span>], grid_to_mesh.inputs[<span class="s">&quot;Grid&quot;</span>])
+    <span class="c"># GN-generated geometry carries no material, so the input mesh&#x27;s material is dropped on</span>
+    <span class="c"># remesh. Re-apply it inside the tree with a Set Material node (the GN-native fix).</span>
+    out_socket = grid_to_mesh.outputs[<span class="s">&quot;Mesh&quot;</span>]
+    <span class="k">if</span> material <span class="k">is</span> <span class="k">not</span> <span class="k">None</span>:
+        set_mat = tree.nodes.new(<span class="s">&#x27;GeometryNodeSetMaterial&#x27;</span>)
+        set_mat.inputs[<span class="s">&quot;Material&quot;</span>].default_value = material
+        tree.links.new(out_socket, set_mat.inputs[<span class="s">&quot;Geometry&quot;</span>])
+        out_socket = set_mat.outputs[<span class="s">&quot;Geometry&quot;</span>]
+    tree.links.new(out_socket, go.inputs[<span class="s">&quot;Geometry&quot;</span>])
+    <span class="k">return</span> tree, link.is_valid
+
+<span class="k">def</span> build():
+    bpy.ops.wm.read_factory_settings(use_empty=<span class="k">True</span>)
+    bpy.ops.mesh.primitive_torus_add(location=(<span class="n">0</span>, <span class="n">0</span>, <span class="n">1.0</span>), major_radius=<span class="n">1.2</span>, minor_radius=<span class="n">0.5</span>)
+    obj = bpy.context.active_object
+    <span class="k">for</span> p <span class="k">in</span> obj.data.polygons:
+        p.use_smooth = <span class="k">True</span>
+    mat = bpy.data.materials.new(<span class="s">&quot;Clay&quot;</span>); mat.use_nodes = <span class="k">True</span>
+    b = mat.node_tree.nodes.get(<span class="s">&#x27;Principled BSDF&#x27;</span>)
+    b.inputs[<span class="s">&#x27;Base Color&#x27;</span>].default_value = (<span class="n">0.45</span>, <span class="n">0.55</span>, <span class="n">0.85</span>, <span class="n">1</span>)
+    b.inputs[<span class="s">&#x27;Roughness&#x27;</span>].default_value = <span class="n">0.45</span>
+    obj.data.materials.append(mat)
+    <span class="k">return</span> obj
+
+<span class="k">def</span> render_still(obj, path, engine):
+    <span class="k">import</span> bmesh
+    sc = bpy.context.scene
+    fme = bpy.data.meshes.new(<span class="s">&quot;Floor&quot;</span>); bm = bmesh.new()
+    bmesh.ops.create_grid(bm, x_segments=<span class="n">1</span>, y_segments=<span class="n">1</span>, size=<span class="n">30.0</span>); bm.to_mesh(fme); bm.free()
+    floor = bpy.data.objects.new(<span class="s">&quot;Floor&quot;</span>, fme); bpy.context.collection.objects.link(floor)
+    w = bpy.data.worlds.new(<span class="s">&quot;W&quot;</span>); w.use_nodes = <span class="k">True</span>
+    w.node_tree.nodes[<span class="s">&quot;Background&quot;</span>].inputs[<span class="n">0</span>].default_value = (<span class="n">0.05</span>, <span class="n">0.06</span>, <span class="n">0.08</span>, <span class="n">1</span>); sc.world = w
+    aim = bpy.data.objects.new(<span class="s">&quot;Aim&quot;</span>, <span class="k">None</span>); aim.location = (<span class="n">0</span>, <span class="n">0</span>, <span class="n">1.0</span>); bpy.context.collection.objects.link(aim)
+    cam = bpy.data.objects.new(<span class="s">&quot;cam&quot;</span>, bpy.data.cameras.new(<span class="s">&quot;cam&quot;</span>)); cam.location = (<span class="n">0</span>, -<span class="n">6.5</span>, <span class="n">3.0</span>)
+    bpy.context.collection.objects.link(cam); sc.camera = cam
+    c = cam.constraints.new(<span class="s">&#x27;TRACK_TO&#x27;</span>); c.target = aim; c.track_axis = <span class="s">&#x27;TRACK_NEGATIVE_Z&#x27;</span>; c.up_axis = <span class="s">&#x27;UP_Y&#x27;</span>
+    <span class="k">for</span> nm, loc, en <span class="k">in</span> [(<span class="s">&quot;K&quot;</span>, (-<span class="n">4</span>, -<span class="n">5</span>, <span class="n">7</span>), <span class="n">900</span>), (<span class="s">&quot;F2&quot;</span>, (<span class="n">5</span>, -<span class="n">4</span>, <span class="n">2</span>), <span class="n">350</span>)]:
+        ld = bpy.data.lights.new(nm, <span class="s">&#x27;AREA&#x27;</span>); ld.energy = en; ld.size = <span class="n">5.0</span>
+        lo = bpy.data.objects.new(nm, ld); lo.location = loc; bpy.context.collection.objects.link(lo)
+        lc = lo.constraints.new(<span class="s">&#x27;TRACK_TO&#x27;</span>); lc.target = aim; lc.track_axis = <span class="s">&#x27;TRACK_NEGATIVE_Z&#x27;</span>; lc.up_axis = <span class="s">&#x27;UP_Y&#x27;</span>
+    sc.render.engine = <span class="s">&#x27;CYCLES&#x27;</span> <span class="k">if</span> engine == <span class="s">&#x27;cycles&#x27;</span> <span class="k">else</span> get_eevee_engine_id()
+    <span class="k">if</span> sc.render.engine == <span class="s">&#x27;CYCLES&#x27;</span>:
+        <span class="k">try</span>: sc.cycles.samples = <span class="n">16</span>
+        <span class="k">except</span> Exception: <span class="k">pass</span>
+    <span class="k">else</span>:
+        <span class="k">try</span>: sc.eevee.taa_render_samples = <span class="n">16</span>
+        <span class="k">except</span> Exception: <span class="k">pass</span>
+    sc.render.resolution_x = <span class="n">1280</span>; sc.render.resolution_y = <span class="n">720</span>
+    sc.render.image_settings.file_format = <span class="s">&#x27;PNG&#x27;</span>; sc.render.filepath = path
+    bpy.ops.render.render(write_still=<span class="k">True</span>)
+    <span class="k">return</span> os.path.exists(path) <span class="k">and</span> os.path.getsize(path) &gt; <span class="n">0</span>
+
+<span class="k">def</span> main():
+    argv = sys.argv[sys.argv.index(<span class="s">&quot;--&quot;</span>) + <span class="n">1</span>:] <span class="k">if</span> <span class="s">&quot;--&quot;</span> <span class="k">in</span> sys.argv <span class="k">else</span> []
+    p = argparse.ArgumentParser()
+    p.add_argument(<span class="s">&quot;--output&quot;</span>, default=<span class="k">None</span>, help=<span class="s">&quot;optional: render the remeshed result to this PNG&quot;</span>)
+    p.add_argument(<span class="s">&quot;--engine&quot;</span>, choices=[<span class="s">&quot;auto&quot;</span>, <span class="s">&quot;cycles&quot;</span>], default=<span class="s">&quot;auto&quot;</span>)
+    args = p.parse_args(argv)
+
+    eid = get_eevee_engine_id()
+    expected = <span class="s">&#x27;BLENDER_EEVEE&#x27;</span> <span class="k">if</span> bpy.app.version &gt;= (<span class="n">5</span>, <span class="n">0</span>, <span class="n">0</span>) <span class="k">else</span> <span class="s">&#x27;BLENDER_EEVEE_NEXT&#x27;</span>
+    bpy.context.scene.render.engine = eid
+    <span class="k">if</span> bpy.context.scene.render.engine != expected:
+        print(<span class="s">f&quot;</span><span class="s">ERROR: EEVEE id </span>{eid}<span class="s"> != expected </span>{expected}<span class="s">&quot;</span>, file=sys.stderr); <span class="k">return</span> <span class="n">5</span>
+
+    obj = build()
+    base = len(obj.data.vertices)
+    src_mat = obj.data.materials[<span class="n">0</span>] <span class="k">if</span> obj.data.materials <span class="k">else</span> <span class="k">None</span>
+    tree, link_valid = build_remesh_via_sdf(material=src_mat)
+    obj.modifiers.new(<span class="s">&quot;sdf&quot;</span>, <span class="s">&#x27;NODES&#x27;</span>).node_group = tree
+    dg = bpy.context.evaluated_depsgraph_get(); ev = obj.evaluated_get(dg)
+    m = ev.to_mesh(); evc = len(m.vertices)
+    mat_names = [mm.name <span class="k">for</span> mm <span class="k">in</span> m.materials <span class="k">if</span> mm <span class="k">is</span> <span class="k">not</span> <span class="k">None</span>]
+    ev.to_mesh_clear()
+    print(<span class="s">f&quot;</span><span class="s">link_valid=</span>{link_valid}<span class="s"> base_vcount=</span>{base}<span class="s"> eval_vcount=</span>{evc}<span class="s"> materials=</span>{mat_names}<span class="s">&quot;</span>)
+    <span class="k">if</span> <span class="k">not</span> (link_valid <span class="k">and</span> evc &gt; <span class="n">0</span> <span class="k">and</span> evc != base):
+        print(<span class="s">&quot;ERROR: SDF remesh produced no/unchanged geometry&quot;</span>, file=sys.stderr); <span class="k">return</span> <span class="n">3</span>
+    <span class="c"># the Set Material node must carry the input material onto the remeshed result</span>
+    <span class="k">if</span> src_mat <span class="k">is</span> <span class="k">not</span> <span class="k">None</span> <span class="k">and</span> src_mat.name <span class="k">not</span> <span class="k">in</span> mat_names:
+        print(<span class="s">f&quot;</span><span class="s">ERROR: material &#x27;</span>{src_mat.name}<span class="s">&#x27; dropped by remesh</span><span class="s">&quot;</span>, file=sys.stderr); <span class="k">return</span> <span class="n">6</span>
+
+    <span class="k">if</span> args.output:
+        <span class="k">if</span> <span class="k">not</span> render_still(obj, args.output, args.engine):
+            print(<span class="s">&quot;ERROR: render produced no file&quot;</span>, file=sys.stderr); <span class="k">return</span> <span class="n">4</span>
+        print(<span class="s">f&quot;</span><span class="s">rendered </span>{args.output}<span class="s"> (</span>{os.path.getsize(args.output)}<span class="s"> bytes)</span><span class="s">&quot;</span>)
+    print(<span class="s">&quot;gn-sdf-remesh OK&quot;</span>)
+    <span class="k">return</span> <span class="n">0</span>
+
+<span class="k">if</span> __name__ == <span class="s">&quot;__main__&quot;</span>:
+    <span class="k">try</span>:
+        sys.exit(main())
+    <span class="k">except</span> Exception <span class="k">as</span> exc:
+        <span class="k">import</span> traceback; traceback.print_exc()
+        print(<span class="s">f&quot;</span><span class="s">FATAL: </span>{type(exc).__name__}<span class="s">: </span>{exc}<span class="s">&quot;</span>, file=sys.stderr); sys.exit(<span class="n">1</span>)
+</pre>
+    </section>
+  </main>
+  <div class="lightbox" id="lightbox" role="dialog" aria-label="Full-size render">
+    <img src="../assets/gn-sdf-remesh-hero.webp" alt="gn-sdf-remesh render, full size" />
+  </div>
+  <footer>
+    Generated from <code>examples/gallery.json</code> by <code>scripts/build_gallery.py</code>.
+    &nbsp;&bull;&nbsp; CC-BY-NC-ND-4.0
+  </footer>
+  <script>
+    (function () {
+      var btn = document.getElementById('themeToggle');
+      var root = document.documentElement;
+      var order = ['auto', 'light', 'dark'];
+      var glyph = { auto: '\u263C', light: '\u2600', dark: '\u263D' };
+      function get() { try { return localStorage.getItem('theme') || 'auto'; } catch (e) { return 'auto'; } }
+      function apply(state) {
+        if (state === 'light' || state === 'dark') root.setAttribute('data-theme', state);
+        else root.removeAttribute('data-theme');
+        try { if (state === 'auto') localStorage.removeItem('theme'); else localStorage.setItem('theme', state); } catch (e) {}
+        btn.innerHTML = glyph[state]; btn.setAttribute('aria-label', 'Theme: ' + state + ' (click to change)');
+      }
+      apply(get());
+      btn.addEventListener('click', function () {
+        var next = order[(order.indexOf(get()) + 1) % order.length];
+        apply(next);
+      });
+    })();
+
+    (function () {
+      var hero = document.getElementById('heroZoom');
+      var box = document.getElementById('lightbox');
+      if (hero && box) {
+        hero.addEventListener('click', function () { box.classList.add('open'); });
+        box.addEventListener('click', function () { box.classList.remove('open'); });
+        document.addEventListener('keydown', function (e) {
+          if (e.key === 'Escape') box.classList.remove('open');
+        });
+      }
+      var copy = document.getElementById('copyRun');
+      if (copy) {
+        copy.addEventListener('click', function () {
+          var cmd = document.getElementById('runCmd').textContent;
+          navigator.clipboard.writeText(cmd).then(function () {
+            copy.textContent = 'Copied!';
+            setTimeout(function () { copy.textContent = 'Copy'; }, 1500);
+          });
+        });
+      }
+    })();
+
+  </script>
+</body>
+</html>

--- a/docs/gallery/swatch-grid/index.html
+++ b/docs/gallery/swatch-grid/index.html
@@ -1,0 +1,485 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>swatch-grid — Examples — Blender Developer Tools</title>
+  <meta name="description" content="Procedural Principled materials — metal and dielectric, the emission pattern, and the cross-version set_specular shim." />
+  <link rel="canonical" href="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/swatch-grid/" />
+  <link rel="icon" href="../../assets/favicon.svg" type="image/svg+xml" />
+  <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)" />
+  <meta name="theme-color" content="#f6f8fa" media="(prefers-color-scheme: light)" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="swatch-grid — Examples — Blender Developer Tools" />
+  <meta property="og:description" content="Procedural Principled materials — metal and dielectric, the emission pattern, and the cross-version set_specular shim." />
+  <meta property="og:url" content="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/swatch-grid/" />
+  <meta property="og:image" content="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/assets/swatch-grid-hero.webp" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="swatch-grid — Examples — Blender Developer Tools" />
+  <meta name="twitter:description" content="Procedural Principled materials — metal and dielectric, the emission pattern, and the cross-version set_specular shim." />
+  <meta name="twitter:image" content="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/assets/swatch-grid-hero.webp" />
+  <!-- FOUC guard: apply the saved theme before first paint. Shares the 'theme'
+       key with the landing page, so a visitor's choice carries across. -->
+  <script>(function(){try{var t=localStorage.getItem('theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <style>
+    :root {
+      --bg: #0d1117; --bg2: #161b22; --surface: #161b22; --surface-2: #1c2128;
+      --border: #30363d; --text: #e6edf3; --text-dim: #8b949e;
+      --accent: #7c3aed; --accent-light: #a78bfa;
+      --radius: 8px; --radius-lg: 12px; --maxw: 1080px;
+      --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      --font-mono: ui-monospace, 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
+      --code-k: #ff7b72; --code-s: #a5d6ff; --code-c: #8b949e; --code-n: #79c0ff;
+    }
+    /* auto mode: follow the OS unless the user forced dark */
+    @media (prefers-color-scheme: light) {
+      :root:not([data-theme="dark"]) {
+        --bg: #f6f8fa; --bg2: #ffffff; --surface: #ffffff; --surface-2: #f0f2f5;
+        --border: #d0d7de; --text: #1f2328; --text-dim: #656d76;
+        --code-k: #cf222e; --code-s: #0a3069; --code-c: #6e7781; --code-n: #0550ae;
+      }
+    }
+    /* explicit override */
+    [data-theme="light"] {
+      --bg: #f6f8fa; --bg2: #ffffff; --surface: #ffffff; --surface-2: #f0f2f5;
+      --border: #d0d7de; --text: #1f2328; --text-dim: #656d76;
+      --code-k: #cf222e; --code-s: #0a3069; --code-c: #6e7781; --code-n: #0550ae;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body { font-family: var(--font-sans); background: var(--bg); color: var(--text);
+      line-height: 1.6; min-height: 100vh; -webkit-font-smoothing: antialiased; }
+    a { color: var(--accent-light); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    :focus-visible { outline: 2px solid var(--accent-light); outline-offset: 2px; border-radius: 3px; }
+    .skip { position: absolute; left: -999px; top: 0; background: var(--accent); color: #fff;
+      padding: 0.5rem 1rem; border-radius: var(--radius); z-index: 10; }
+    .skip:focus { left: 0.5rem; top: 0.5rem; }
+
+    .topbar { position: sticky; top: 0; z-index: 5; display: flex; align-items: center;
+      justify-content: space-between; gap: 1rem; padding: 0.75rem 1.25rem;
+      background: color-mix(in srgb, var(--bg) 88%, transparent);
+      backdrop-filter: blur(10px); border-bottom: 1px solid var(--border); }
+    .topbar .back { color: var(--text-dim); font-size: 0.9rem; font-weight: 500; }
+    .topbar .back:hover { color: var(--accent-light); }
+    .topbar-right { display: flex; align-items: center; gap: 0.85rem; }
+    .topbar-right .ghlink { color: var(--text-dim); font-size: 0.9rem; font-weight: 500; }
+    .topbar-right .ghlink:hover { color: var(--accent-light); }
+    .theme-toggle { background: var(--surface-2); border: 1px solid var(--border);
+      color: var(--text); border-radius: var(--radius); padding: 0.35rem 0.6rem;
+      font-size: 0.95rem; cursor: pointer; line-height: 1; transition: border-color 0.15s, background 0.15s; }
+    .theme-toggle:hover { border-color: var(--accent-light); }
+
+    header.hero { max-width: var(--maxw); margin: 0 auto; padding: 3rem 1.25rem 1.5rem; }
+    header.hero h1 { font-size: clamp(1.9rem, 4vw, 2.6rem); letter-spacing: -0.02em; line-height: 1.15; }
+    header.hero p { color: var(--text-dim); max-width: 62ch; margin-top: 0.6rem; font-size: 1.02rem; }
+
+    /* ---- index: filter chips ---- */
+    .chips { max-width: var(--maxw); margin: 0 auto; padding: 0 1.25rem 0.25rem;
+      display: flex; flex-wrap: wrap; gap: 0.5rem; }
+    .chip { background: var(--surface-2); border: 1px solid var(--border); color: var(--text-dim);
+      border-radius: 999px; padding: 0.25rem 0.85rem; font-size: 0.82rem; font-weight: 500;
+      font-family: var(--font-sans); cursor: pointer; transition: color 0.15s, border-color 0.15s; }
+    .chip:hover { color: var(--accent-light); border-color: var(--accent); }
+    .chip.active { color: #fff; background: var(--accent); border-color: var(--accent); }
+
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem 1.25rem 2rem; }
+    .grid { display: grid; grid-template-columns: 1fr; gap: 1.5rem; align-items: stretch; }
+    .card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg);
+      overflow: hidden; display: flex; flex-direction: column;
+      transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease; }
+    .card:hover { transform: translateY(-3px); border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+      box-shadow: 0 8px 28px rgba(0,0,0,0.28); }
+    .card.hidden { display: none; }
+    .card-media { display: block; background: var(--bg2); line-height: 0; }
+    .card-media img { display: block; width: 100%; aspect-ratio: 16 / 9; object-fit: cover; }
+    .card-body { padding: 1.15rem 1.4rem 1.45rem; display: flex; flex-direction: column; flex: 1 1 auto; }
+    .card-body h2 { font-size: 1.22rem; letter-spacing: -0.01em; margin-bottom: 0.5rem; }
+    .card-body h2 a { color: var(--text); }
+    .card-body h2 a:hover { color: var(--accent-light); text-decoration: none; }
+    .teaches { color: var(--text); margin-bottom: 0.7rem; }
+    .witnesses { color: var(--text-dim); font-size: 0.9rem; margin-bottom: 1rem; }
+    .tag { display: inline-block; font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.06em;
+      color: var(--accent-light); border: 1px solid color-mix(in srgb, var(--accent) 60%, transparent);
+      border-radius: 999px; padding: 0.08rem 0.55rem; margin-right: 0.4rem; vertical-align: 1px; }
+    .card-link { font-weight: 600; font-size: 0.95rem; margin-top: auto; }
+
+    /* ---- detail page ---- */
+    .detail-hero { border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden;
+      background: var(--bg2); padding: 0; display: block; width: 100%; cursor: zoom-in; line-height: 0; }
+    .detail-hero img { display: block; width: 100%; aspect-ratio: 16 / 9; object-fit: cover; }
+    .zoom-hint { color: var(--text-dim); font-size: 0.78rem; margin-top: 0.4rem; }
+    .callout { border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
+      border-left: 3px solid var(--accent); border-radius: var(--radius);
+      background: color-mix(in srgb, var(--accent) 7%, var(--surface));
+      padding: 0.85rem 1.1rem; margin: 1.5rem 0; font-size: 0.95rem; }
+    .runline { display: flex; align-items: stretch; gap: 0.5rem; margin: 1.5rem 0; }
+    .runline pre { flex: 1 1 auto; background: var(--surface-2); border: 1px solid var(--border);
+      border-radius: var(--radius); padding: 0.7rem 0.9rem; overflow-x: auto;
+      font-family: var(--font-mono); font-size: 0.83rem; line-height: 1.5; }
+    .copy-btn { flex: 0 0 auto; background: var(--surface-2); border: 1px solid var(--border);
+      color: var(--text-dim); border-radius: var(--radius); padding: 0 0.85rem; cursor: pointer;
+      font-family: var(--font-sans); font-size: 0.82rem; font-weight: 500; transition: color 0.15s, border-color 0.15s; }
+    .copy-btn:hover { color: var(--accent-light); border-color: var(--accent); }
+    .detail-section { margin-top: 2.25rem; }
+    .detail-section > h2 { font-size: 1.15rem; letter-spacing: -0.01em; padding-bottom: 0.5rem;
+      border-bottom: 1px solid var(--border); margin-bottom: 1rem; }
+
+    .md h1, .md h2, .md h3 { letter-spacing: -0.01em; margin: 1.4rem 0 0.6rem; line-height: 1.25; }
+    .md h1 { font-size: 1.35rem; } .md h2 { font-size: 1.15rem; } .md h3 { font-size: 1rem; }
+    .md p { margin: 0.7rem 0; }
+    .md ul { margin: 0.7rem 0 0.7rem 1.4rem; }
+    .md li { margin: 0.3rem 0; }
+    .md code { background: var(--surface-2); border: 1px solid var(--border); padding: 0.08rem 0.35rem;
+      border-radius: 4px; font-family: var(--font-mono); font-size: 0.84em; }
+    .md pre { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius);
+      padding: 0.85rem 1rem; overflow-x: auto; margin: 0.9rem 0; }
+    .md pre code { background: none; border: none; padding: 0; font-size: 0.83rem; line-height: 1.55; }
+
+    .src pre { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius);
+      padding: 1rem 1.1rem; overflow-x: auto; font-family: var(--font-mono);
+      font-size: 0.82rem; line-height: 1.55; }
+    .src .k { color: var(--code-k); } .src .s { color: var(--code-s); }
+    .src .c { color: var(--code-c); font-style: italic; } .src .n { color: var(--code-n); }
+    .src-meta { display: flex; justify-content: space-between; align-items: baseline; gap: 1rem;
+      flex-wrap: wrap; margin-bottom: 0.6rem; color: var(--text-dim); font-size: 0.85rem; }
+    .src-meta code { font-family: var(--font-mono); font-size: 0.82rem; }
+
+    .lightbox { position: fixed; inset: 0; z-index: 50; display: none; align-items: center;
+      justify-content: center; background: rgba(0,0,0,0.85); padding: 2rem; cursor: zoom-out; }
+    .lightbox.open { display: flex; }
+    .lightbox img { max-width: 100%; max-height: 100%; border-radius: var(--radius); }
+
+    footer { max-width: var(--maxw); margin: 0 auto; padding: 2rem 1.25rem 3rem;
+      color: var(--text-dim); font-size: 0.85rem; border-top: 1px solid var(--border); }
+    footer code { background: var(--surface-2); padding: 0.1rem 0.35rem; border-radius: 4px; font-size: 0.82rem; }
+
+    @media (min-width: 720px) { .grid { grid-template-columns: 1fr 1fr; gap: 1.75rem; } }
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+      .card, .theme-toggle { transition: none; }
+      .card:hover { transform: none; }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip" href="#main">Skip to content</a>
+  <div class="topbar">
+    <a class="back" href="../"><span aria-hidden="true">&larr;</span> Examples Gallery</a>
+    <div class="topbar-right">
+      <a class="ghlink" href="https://github.com/TMHSDigital/Blender-Developer-Tools">GitHub</a>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Theme: auto (click to change)">&#9788;</button>
+    </div>
+  </div>
+  <header class="hero">
+    <h1>swatch-grid</h1>
+    <p>Procedural Principled materials — metal and dielectric, the emission pattern, and the cross-version set_specular shim.</p>
+  </header>
+  <main id="main">
+    <button class="detail-hero" id="heroZoom" type="button" aria-label="Zoom swatch-grid render">
+      <img src="../assets/swatch-grid-hero.webp" alt="swatch-grid render" width="1280" height="720" />
+    </button>
+    <p class="zoom-hint">Rendered headless by the example itself — click to zoom.</p>
+    <div class="callout"><span class="tag">witnesses</span> EEVEE engine-id mapping: BLENDER_EEVEE on 5.x, BLENDER_EEVEE_NEXT on 4.2–4.5.</div>
+    <div class="runline">
+      <pre id="runCmd">blender --background --python examples/swatch-grid/swatch_grid.py --</pre>
+      <button class="copy-btn" id="copyRun" type="button">Copy</button>
+    </div>
+    <section class="detail-section md">
+<p>A runnable example that renders a 3×2 grid of spheres — one material per cell — to a single PNG. It demonstrates the <a href="https://github.com/TMHSDigital/Blender-Developer-Tools/tree/main/skills/procedural-materials-and-shaders/SKILL.md"><code>procedural-materials-and-shaders</code></a> patterns end to end:</p>
+<ul><li><strong>Principled BSDF</strong> metals (gold, copper: high metallic, low roughness) and dielectrics (red/blue plastic, white rough), configured with <strong>string socket lookups</strong> and <strong>4-tuple colors</strong>.</li><li>The <strong>emission</strong> pattern (an emissive orange swatch).</li><li>The cross-version <strong><code>set_specular</code> shim</strong> (<code>Specular</code> → <code>Specular IOR Level</code>, renamed in Blender 4.0).</li></ul>
+<p>It doubles as a live proof of the <strong>EEVEE engine-id</strong> behavior: the version-branch helper resolves <code>BLENDER_EEVEE</code> on Blender 5.x and <code>BLENDER_EEVEE_NEXT</code> on 4.2–4.5, and the chosen id is asserted against the running build before rendering — so a regression in that mapping fails the example, not just the docs.</p>
+<h2>Run</h2>
+<pre><code># Default: render with the build&#x27;s EEVEE engine (needs a GPU/display)
+blender --background --python swatch_grid.py -- --output swatch.png
+
+# GPU-less / CI hosts: render the pixels with Cycles (CPU). The EEVEE id is still
+# asserted; only the final pixels use Cycles.
+blender --background --python swatch_grid.py -- --output swatch.png --engine cycles --samples 16 --width 960</code></pre>
+<p>The script is deterministic and dependency-light (fixed camera and layout, no HDRI, no network). It <strong>exits non-zero</strong> on any failure, including a render that comes out uniformly black or without the expected six distinct swatch regions — the same honest check the CI smoke gate runs on both Blender 4.5 LTS and 5.1.</p>
+<h2>Verified</h2>
+<p>Runs headless on <strong>Blender 4.5.10 LTS</strong> and <strong>5.1.1</strong>; exercised on both by the <code>blender-smoke</code> workflow on every PR and weekly schedule.</p>
+    </section>
+    <section class="detail-section src">
+      <h2>Source</h2>
+      <div class="src-meta">
+        <code>examples/swatch-grid/swatch_grid.py</code>
+        <a href="https://github.com/TMHSDigital/Blender-Developer-Tools/tree/main/examples/swatch-grid/swatch_grid.py">View on GitHub &rarr;</a>
+      </div>
+      <pre><span class="s">&quot;&quot;&quot;Procedural-materials swatch grid -- a runnable BDT example.
+
+Renders a 3x2 grid of spheres, one per material, demonstrating the
+`procedural-materials-and-shaders` patterns end to end: Principled BSDF (metal +
+dielectric), the emission pattern, the cross-version `set_specular` shim, string socket
+lookups, and 4-tuple colors. It also doubles as a live proof of the EEVEE engine-id fix:
+the version-branch helper resolves `BLENDER_EEVEE` on Blender 5.x and `BLENDER_EEVEE_NEXT`
+on 4.2-4.5, and the chosen id is asserted against the build before rendering.
+
+Run headless:
+    blender --background --python swatch_grid.py -- --output swatch.png
+    blender --background --python swatch_grid.py -- --output s.png --engine cycles --samples 8 --width 640
+
+Dependency-light and deterministic (fixed camera/layout, no HDRI, no network). Exits
+non-zero on any failure, including a render that comes out black or without the expected
+number of distinct swatch regions.
+&quot;&quot;&quot;</span>
+<span class="k">import</span> bpy
+<span class="k">import</span> bmesh
+<span class="k">import</span> sys
+<span class="k">import</span> os
+<span class="k">import</span> math
+<span class="k">import</span> argparse
+<span class="k">import</span> numpy <span class="k">as</span> np
+
+GRID_COLS, GRID_ROWS = <span class="n">3</span>, <span class="n">2</span>
+MATERIAL_COUNT = GRID_COLS * GRID_ROWS  <span class="c"># 6</span>
+
+
+<span class="c"># --- patterns copied from the procedural-materials-and-shaders skill ---</span>
+<span class="k">def</span> get_eevee_engine_id():
+    <span class="s">&quot;&quot;&quot;EEVEE id: &#x27;BLENDER_EEVEE&#x27; on 5.0+, &#x27;BLENDER_EEVEE_NEXT&#x27; on 4.2-4.5.&quot;&quot;&quot;</span>
+    <span class="k">return</span> <span class="s">&#x27;BLENDER_EEVEE&#x27;</span> <span class="k">if</span> bpy.app.version &gt;= (<span class="n">5</span>, <span class="n">0</span>, <span class="n">0</span>) <span class="k">else</span> <span class="s">&#x27;BLENDER_EEVEE_NEXT&#x27;</span>
+
+
+<span class="k">def</span> set_specular(bsdf, value):
+    <span class="s">&quot;&quot;&quot;&#x27;Specular&#x27; was renamed to &#x27;Specular IOR Level&#x27; in Blender 4.0; support both.&quot;&quot;&quot;</span>
+    <span class="k">if</span> <span class="s">&#x27;Specular IOR Level&#x27;</span> <span class="k">in</span> bsdf.inputs:
+        bsdf.inputs[<span class="s">&#x27;Specular IOR Level&#x27;</span>].default_value = value
+        <span class="k">return</span> <span class="s">&#x27;Specular IOR Level&#x27;</span>
+    <span class="k">if</span> <span class="s">&#x27;Specular&#x27;</span> <span class="k">in</span> bsdf.inputs:
+        bsdf.inputs[<span class="s">&#x27;Specular&#x27;</span>].default_value = value
+        <span class="k">return</span> <span class="s">&#x27;Specular&#x27;</span>
+    <span class="k">return</span> <span class="k">None</span>
+
+
+<span class="k">def</span> make_principled(name, base_color, metallic, roughness, specular=<span class="k">None</span>):
+    mat = bpy.data.materials.new(name)
+    mat.use_nodes = <span class="k">True</span>
+    nt = mat.node_tree
+    nt.nodes.clear()
+    bsdf = nt.nodes.new(<span class="s">&#x27;ShaderNodeBsdfPrincipled&#x27;</span>)
+    bsdf.inputs[<span class="s">&#x27;Base Color&#x27;</span>].default_value = base_color
+    bsdf.inputs[<span class="s">&#x27;Metallic&#x27;</span>].default_value = metallic
+    bsdf.inputs[<span class="s">&#x27;Roughness&#x27;</span>].default_value = roughness
+    resolved = set_specular(bsdf, specular) <span class="k">if</span> specular <span class="k">is</span> <span class="k">not</span> <span class="k">None</span> <span class="k">else</span> <span class="k">None</span>
+    out = nt.nodes.new(<span class="s">&#x27;ShaderNodeOutputMaterial&#x27;</span>)
+    nt.links.new(bsdf.outputs[<span class="s">&#x27;BSDF&#x27;</span>], out.inputs[<span class="s">&#x27;Surface&#x27;</span>])
+    <span class="k">return</span> mat, resolved
+
+
+<span class="k">def</span> make_emissive(name, color, strength):
+    mat = bpy.data.materials.new(name)
+    mat.use_nodes = <span class="k">True</span>
+    nt = mat.node_tree
+    nt.nodes.clear()
+    emis = nt.nodes.new(<span class="s">&#x27;ShaderNodeEmission&#x27;</span>)
+    emis.inputs[<span class="s">&#x27;Color&#x27;</span>].default_value = color
+    emis.inputs[<span class="s">&#x27;Strength&#x27;</span>].default_value = strength
+    out = nt.nodes.new(<span class="s">&#x27;ShaderNodeOutputMaterial&#x27;</span>)
+    nt.links.new(emis.outputs[<span class="s">&#x27;Emission&#x27;</span>], out.inputs[<span class="s">&#x27;Surface&#x27;</span>])
+    <span class="k">return</span> mat
+
+
+<span class="k">def</span> build_materials():
+    <span class="s">&quot;&quot;&quot;Return a list of (material, label) covering metal, dielectric, emissive, and the
+    set_specular shim. The list order maps left-to-right, top-to-bottom across the grid.&quot;&quot;&quot;</span>
+    mats, specular_socket = [], <span class="k">None</span>
+    m, specular_socket = make_principled(<span class="s">&quot;Gold&quot;</span>, (<span class="n">1.00</span>, <span class="n">0.77</span>, <span class="n">0.34</span>, <span class="n">1</span>), <span class="n">1.0</span>, <span class="n">0.15</span>)
+    mats.append(m)
+    m, _ = make_principled(<span class="s">&quot;Copper&quot;</span>, (<span class="n">0.95</span>, <span class="n">0.64</span>, <span class="n">0.54</span>, <span class="n">1</span>), <span class="n">1.0</span>, <span class="n">0.28</span>)
+    mats.append(m)
+    m, sr = make_principled(<span class="s">&quot;RedPlastic&quot;</span>, (<span class="n">0.80</span>, <span class="n">0.05</span>, <span class="n">0.05</span>, <span class="n">1</span>), <span class="n">0.0</span>, <span class="n">0.40</span>, specular=<span class="n">0.5</span>)
+    mats.append(m)
+    specular_socket = specular_socket <span class="k">or</span> sr
+    m, _ = make_principled(<span class="s">&quot;BluePlastic&quot;</span>, (<span class="n">0.05</span>, <span class="n">0.20</span>, <span class="n">0.80</span>, <span class="n">1</span>), <span class="n">0.0</span>, <span class="n">0.30</span>, specular=<span class="n">0.5</span>)
+    mats.append(m)
+    mats.append(make_emissive(<span class="s">&quot;EmissiveOrange&quot;</span>, (<span class="n">1.0</span>, <span class="n">0.35</span>, <span class="n">0.05</span>, <span class="n">1</span>), <span class="n">6.0</span>))
+    m, _ = make_principled(<span class="s">&quot;WhiteRough&quot;</span>, (<span class="n">0.90</span>, <span class="n">0.90</span>, <span class="n">0.92</span>, <span class="n">1</span>), <span class="n">0.0</span>, <span class="n">0.70</span>, specular=<span class="n">0.3</span>)
+    mats.append(m)
+    <span class="k">return</span> mats, specular_socket
+
+
+<span class="k">def</span> build_scene(mats):
+    xs = [-<span class="n">2.2</span>, <span class="n">0.0</span>, <span class="n">2.2</span>]
+    zs = [<span class="n">1.1</span>, -<span class="n">1.1</span>]
+    i = <span class="n">0</span>
+    <span class="k">for</span> r <span class="k">in</span> range(GRID_ROWS):
+        <span class="k">for</span> c <span class="k">in</span> range(GRID_COLS):
+            me = bpy.data.meshes.new(<span class="s">f&quot;</span><span class="s">S</span>{i}<span class="s">&quot;</span>)
+            bm = bmesh.new()
+            bmesh.ops.create_uvsphere(bm, u_segments=<span class="n">48</span>, v_segments=<span class="n">24</span>, radius=<span class="n">0.92</span>)
+            bm.to_mesh(me)
+            bm.free()
+            <span class="k">for</span> poly <span class="k">in</span> me.polygons:
+                poly.use_smooth = <span class="k">True</span>
+            ob = bpy.data.objects.new(<span class="s">f&quot;</span><span class="s">S</span>{i}<span class="s">&quot;</span>, me)
+            ob.location = (xs[c], <span class="n">0.0</span>, zs[r])
+            bpy.context.collection.objects.link(ob)
+            ob.data.materials.append(mats[i])
+            i += <span class="n">1</span>
+    <span class="c"># ortho camera framed exactly on the grid cells</span>
+    cam_d = bpy.data.cameras.new(<span class="s">&quot;cam&quot;</span>)
+    cam_d.type = <span class="s">&#x27;ORTHO&#x27;</span>
+    cam_d.ortho_scale = <span class="n">6.6</span>
+    cam = bpy.data.objects.new(<span class="s">&quot;cam&quot;</span>, cam_d)
+    cam.location = (<span class="n">0.0</span>, -<span class="n">10.0</span>, <span class="n">0.0</span>)
+    cam.rotation_euler = (math.radians(<span class="n">90</span>), <span class="n">0</span>, <span class="n">0</span>)
+    bpy.context.collection.objects.link(cam)
+    bpy.context.scene.camera = cam
+    aim = bpy.data.objects.new(<span class="s">&quot;Aim&quot;</span>, <span class="k">None</span>)
+    bpy.context.collection.objects.link(aim)
+    <span class="k">for</span> lname, loc, energy <span class="k">in</span> [(<span class="s">&quot;KeyL&quot;</span>, (-<span class="n">5</span>, -<span class="n">6</span>, <span class="n">4</span>), <span class="n">1500</span>), (<span class="s">&quot;FillL&quot;</span>, (<span class="n">5</span>, -<span class="n">6</span>, -<span class="n">2</span>), <span class="n">700</span>)]:
+        ld = bpy.data.lights.new(lname, <span class="s">&#x27;AREA&#x27;</span>)
+        ld.energy = energy
+        ld.size = <span class="n">5.0</span>
+        lo = bpy.data.objects.new(lname, ld)
+        lo.location = loc
+        bpy.context.collection.objects.link(lo)
+        con = lo.constraints.new(<span class="s">&#x27;TRACK_TO&#x27;</span>)
+        con.target = aim
+        con.track_axis = <span class="s">&#x27;TRACK_NEGATIVE_Z&#x27;</span>
+        con.up_axis = <span class="s">&#x27;UP_Y&#x27;</span>
+    world = bpy.data.worlds.new(<span class="s">&quot;W&quot;</span>)
+    world.use_nodes = <span class="k">True</span>
+    world.node_tree.nodes[<span class="s">&quot;Background&quot;</span>].inputs[<span class="n">0</span>].default_value = (<span class="n">0.03</span>, <span class="n">0.03</span>, <span class="n">0.035</span>, <span class="n">1</span>)
+    bpy.context.scene.world = world
+
+
+<span class="k">def</span> verify_png(path):
+    <span class="s">&quot;&quot;&quot;Honest capture: not uniformly black AND distinct swatch regions == MATERIAL_COUNT.&quot;&quot;&quot;</span>
+    img = bpy.data.images.load(path)
+    w, h = img.size
+    arr = np.array(img.pixels[:], dtype=np.float32).reshape(h, w, <span class="n">4</span>)[..., :<span class="n">3</span>]
+    gmax = float(arr.max())
+    cw, ch, ph = w // GRID_COLS, h // GRID_ROWS, <span class="n">24</span>
+    means = []
+    <span class="k">for</span> r <span class="k">in</span> range(GRID_ROWS):
+        <span class="k">for</span> c <span class="k">in</span> range(GRID_COLS):
+            cx, cy = c * cw + cw // <span class="n">2</span>, r * ch + ch // <span class="n">2</span>
+            means.append(arr[cy - ph:cy + ph, cx - ph:cx + ph, :].reshape(-<span class="n">1</span>, <span class="n">3</span>).mean(axis=<span class="n">0</span>))
+    kept = []
+    <span class="k">for</span> cm <span class="k">in</span> means:
+        <span class="k">if</span> all(np.linalg.norm(cm - k) &gt; <span class="n">0.10</span> <span class="k">for</span> k <span class="k">in</span> kept):
+            kept.append(cm)
+    <span class="k">return</span> gmax, len(kept)
+
+
+<span class="k">def</span> main():
+    argv = sys.argv[sys.argv.index(<span class="s">&quot;--&quot;</span>) + <span class="n">1</span>:] <span class="k">if</span> <span class="s">&quot;--&quot;</span> <span class="k">in</span> sys.argv <span class="k">else</span> []
+    p = argparse.ArgumentParser(description=<span class="s">&quot;Render a procedural-materials swatch grid.&quot;</span>)
+    p.add_argument(<span class="s">&quot;--output&quot;</span>, required=<span class="k">True</span>, help=<span class="s">&quot;Output PNG path&quot;</span>)
+    p.add_argument(<span class="s">&quot;--engine&quot;</span>, choices=[<span class="s">&quot;auto&quot;</span>, <span class="s">&quot;eevee&quot;</span>, <span class="s">&quot;cycles&quot;</span>], default=<span class="s">&quot;auto&quot;</span>,
+                   help=<span class="s">&quot;auto/eevee use the version-correct EEVEE id; cycles for GPU-less hosts&quot;</span>)
+    p.add_argument(<span class="s">&quot;--samples&quot;</span>, type=int, default=<span class="n">32</span>)
+    p.add_argument(<span class="s">&quot;--width&quot;</span>, type=int, default=<span class="n">1280</span>)
+    p.add_argument(<span class="s">&quot;--no-verify&quot;</span>, action=<span class="s">&quot;store_true&quot;</span>)
+    args = p.parse_args(argv)
+
+    <span class="c"># Empty the factory file FIRST so the materials we create below survive.</span>
+    bpy.ops.wm.read_factory_settings(use_empty=<span class="k">True</span>)
+    mats, specular_socket = build_materials()
+    build_scene(mats)
+
+    sc = bpy.context.scene
+    <span class="c"># EEVEE engine-id proof: frame-independent, must hold even when we render with Cycles.</span>
+    eid = get_eevee_engine_id()
+    expected = <span class="s">&#x27;BLENDER_EEVEE&#x27;</span> <span class="k">if</span> bpy.app.version &gt;= (<span class="n">5</span>, <span class="n">0</span>, <span class="n">0</span>) <span class="k">else</span> <span class="s">&#x27;BLENDER_EEVEE_NEXT&#x27;</span>
+    sc.render.engine = eid
+    <span class="k">if</span> sc.render.engine != expected:
+        print(<span class="s">f&quot;</span><span class="s">ERROR: EEVEE id helper returned &#x27;</span>{eid}<span class="s">&#x27;, engine is &#x27;</span>{sc.render.engine}<span class="s">&#x27;, </span><span class="s">&quot;</span>
+              <span class="s">f&quot;</span><span class="s">expected &#x27;</span>{expected}<span class="s">&#x27;</span><span class="s">&quot;</span>, file=sys.stderr)
+        <span class="k">return</span> <span class="n">5</span>
+    print(<span class="s">f&quot;</span><span class="s">eevee_engine_id=</span>{eid}<span class="s"> (expected </span>{expected}<span class="s">) OK; set_specular resolved &#x27;</span>{specular_socket}<span class="s">&#x27;</span><span class="s">&quot;</span>)
+
+    render_engine = <span class="s">&#x27;CYCLES&#x27;</span> <span class="k">if</span> args.engine == <span class="s">&#x27;cycles&#x27;</span> <span class="k">else</span> eid
+    sc.render.engine = render_engine
+    <span class="k">if</span> render_engine == <span class="s">&#x27;CYCLES&#x27;</span>:
+        sc.cycles.samples = args.samples
+    <span class="k">else</span>:
+        sc.eevee.taa_render_samples = args.samples
+    sc.render.resolution_x = args.width
+    sc.render.resolution_y = int(args.width * <span class="n">9</span> / <span class="n">16</span>)
+    sc.render.image_settings.file_format = <span class="s">&#x27;PNG&#x27;</span>
+    sc.render.filepath = args.output
+    os.makedirs(os.path.dirname(os.path.abspath(args.output)) <span class="k">or</span> <span class="s">&quot;.&quot;</span>, exist_ok=<span class="k">True</span>)
+    bpy.ops.render.render(write_still=<span class="k">True</span>)
+    <span class="k">if</span> <span class="k">not</span> (os.path.exists(args.output) <span class="k">and</span> os.path.getsize(args.output) &gt; <span class="n">0</span>):
+        print(<span class="s">&quot;ERROR: no output written&quot;</span>, file=sys.stderr)
+        <span class="k">return</span> <span class="n">4</span>
+    print(<span class="s">f&quot;</span><span class="s">rendered </span>{args.output}<span class="s"> with </span>{render_engine}<span class="s"> (</span>{os.path.getsize(args.output)}<span class="s"> bytes)</span><span class="s">&quot;</span>)
+
+    <span class="k">if</span> <span class="k">not</span> args.no_verify:
+        gmax, regions = verify_png(args.output)
+        non_black = gmax &gt; <span class="n">0.05</span>
+        regions_ok = regions == MATERIAL_COUNT
+        print(<span class="s">f&quot;</span><span class="s">verify: max_pixel=</span>{gmax:<span class="s">.3f</span>}<span class="s"> non_black=</span>{non_black}<span class="s"> </span><span class="s">&quot;</span>
+              <span class="s">f&quot;</span><span class="s">distinct_regions=</span>{regions}<span class="s"> materials=</span>{MATERIAL_COUNT}<span class="s"> ok=</span>{regions_ok}<span class="s">&quot;</span>)
+        <span class="k">if</span> <span class="k">not</span> (non_black <span class="k">and</span> regions_ok):
+            print(<span class="s">&quot;ERROR: render failed verification (black or wrong region count)&quot;</span>, file=sys.stderr)
+            <span class="k">return</span> <span class="n">3</span>
+    <span class="k">return</span> <span class="n">0</span>
+
+
+<span class="k">if</span> __name__ == <span class="s">&quot;__main__&quot;</span>:
+    <span class="k">try</span>:
+        sys.exit(main())
+    <span class="k">except</span> Exception <span class="k">as</span> exc:  <span class="c"># blender exits 0 on an uncaught traceback; force non-zero</span>
+        <span class="k">import</span> traceback
+        traceback.print_exc()
+        print(<span class="s">f&quot;</span><span class="s">FATAL: </span>{type(exc).__name__}<span class="s">: </span>{exc}<span class="s">&quot;</span>, file=sys.stderr)
+        sys.exit(<span class="n">1</span>)
+</pre>
+    </section>
+  </main>
+  <div class="lightbox" id="lightbox" role="dialog" aria-label="Full-size render">
+    <img src="../assets/swatch-grid-hero.webp" alt="swatch-grid render, full size" />
+  </div>
+  <footer>
+    Generated from <code>examples/gallery.json</code> by <code>scripts/build_gallery.py</code>.
+    &nbsp;&bull;&nbsp; CC-BY-NC-ND-4.0
+  </footer>
+  <script>
+    (function () {
+      var btn = document.getElementById('themeToggle');
+      var root = document.documentElement;
+      var order = ['auto', 'light', 'dark'];
+      var glyph = { auto: '\u263C', light: '\u2600', dark: '\u263D' };
+      function get() { try { return localStorage.getItem('theme') || 'auto'; } catch (e) { return 'auto'; } }
+      function apply(state) {
+        if (state === 'light' || state === 'dark') root.setAttribute('data-theme', state);
+        else root.removeAttribute('data-theme');
+        try { if (state === 'auto') localStorage.removeItem('theme'); else localStorage.setItem('theme', state); } catch (e) {}
+        btn.innerHTML = glyph[state]; btn.setAttribute('aria-label', 'Theme: ' + state + ' (click to change)');
+      }
+      apply(get());
+      btn.addEventListener('click', function () {
+        var next = order[(order.indexOf(get()) + 1) % order.length];
+        apply(next);
+      });
+    })();
+
+    (function () {
+      var hero = document.getElementById('heroZoom');
+      var box = document.getElementById('lightbox');
+      if (hero && box) {
+        hero.addEventListener('click', function () { box.classList.add('open'); });
+        box.addEventListener('click', function () { box.classList.remove('open'); });
+        document.addEventListener('keydown', function (e) {
+          if (e.key === 'Escape') box.classList.remove('open');
+        });
+      }
+      var copy = document.getElementById('copyRun');
+      if (copy) {
+        copy.addEventListener('click', function () {
+          var cmd = document.getElementById('runCmd').textContent;
+          navigator.clipboard.writeText(cmd).then(function () {
+            copy.textContent = 'Copied!';
+            setTimeout(function () { copy.textContent = 'Copy'; }, 1500);
+          });
+        });
+      }
+    })();
+
+  </script>
+</body>
+</html>

--- a/docs/gallery/turntable/index.html
+++ b/docs/gallery/turntable/index.html
@@ -1,0 +1,389 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>turntable — Examples — Blender Developer Tools</title>
+  <meta name="description" content="A slotted-actions Z-rotation turntable keyed through the cross-version channelbag path (get_channelbag_for_slot)." />
+  <link rel="canonical" href="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/turntable/" />
+  <link rel="icon" href="../../assets/favicon.svg" type="image/svg+xml" />
+  <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)" />
+  <meta name="theme-color" content="#f6f8fa" media="(prefers-color-scheme: light)" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="turntable — Examples — Blender Developer Tools" />
+  <meta property="og:description" content="A slotted-actions Z-rotation turntable keyed through the cross-version channelbag path (get_channelbag_for_slot)." />
+  <meta property="og:url" content="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/turntable/" />
+  <meta property="og:image" content="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/assets/turntable-hero.webp" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="turntable — Examples — Blender Developer Tools" />
+  <meta name="twitter:description" content="A slotted-actions Z-rotation turntable keyed through the cross-version channelbag path (get_channelbag_for_slot)." />
+  <meta name="twitter:image" content="https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/assets/turntable-hero.webp" />
+  <!-- FOUC guard: apply the saved theme before first paint. Shares the 'theme'
+       key with the landing page, so a visitor's choice carries across. -->
+  <script>(function(){try{var t=localStorage.getItem('theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
+  <style>
+    :root {
+      --bg: #0d1117; --bg2: #161b22; --surface: #161b22; --surface-2: #1c2128;
+      --border: #30363d; --text: #e6edf3; --text-dim: #8b949e;
+      --accent: #7c3aed; --accent-light: #a78bfa;
+      --radius: 8px; --radius-lg: 12px; --maxw: 1080px;
+      --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      --font-mono: ui-monospace, 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
+      --code-k: #ff7b72; --code-s: #a5d6ff; --code-c: #8b949e; --code-n: #79c0ff;
+    }
+    /* auto mode: follow the OS unless the user forced dark */
+    @media (prefers-color-scheme: light) {
+      :root:not([data-theme="dark"]) {
+        --bg: #f6f8fa; --bg2: #ffffff; --surface: #ffffff; --surface-2: #f0f2f5;
+        --border: #d0d7de; --text: #1f2328; --text-dim: #656d76;
+        --code-k: #cf222e; --code-s: #0a3069; --code-c: #6e7781; --code-n: #0550ae;
+      }
+    }
+    /* explicit override */
+    [data-theme="light"] {
+      --bg: #f6f8fa; --bg2: #ffffff; --surface: #ffffff; --surface-2: #f0f2f5;
+      --border: #d0d7de; --text: #1f2328; --text-dim: #656d76;
+      --code-k: #cf222e; --code-s: #0a3069; --code-c: #6e7781; --code-n: #0550ae;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html { scroll-behavior: smooth; }
+    body { font-family: var(--font-sans); background: var(--bg); color: var(--text);
+      line-height: 1.6; min-height: 100vh; -webkit-font-smoothing: antialiased; }
+    a { color: var(--accent-light); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    :focus-visible { outline: 2px solid var(--accent-light); outline-offset: 2px; border-radius: 3px; }
+    .skip { position: absolute; left: -999px; top: 0; background: var(--accent); color: #fff;
+      padding: 0.5rem 1rem; border-radius: var(--radius); z-index: 10; }
+    .skip:focus { left: 0.5rem; top: 0.5rem; }
+
+    .topbar { position: sticky; top: 0; z-index: 5; display: flex; align-items: center;
+      justify-content: space-between; gap: 1rem; padding: 0.75rem 1.25rem;
+      background: color-mix(in srgb, var(--bg) 88%, transparent);
+      backdrop-filter: blur(10px); border-bottom: 1px solid var(--border); }
+    .topbar .back { color: var(--text-dim); font-size: 0.9rem; font-weight: 500; }
+    .topbar .back:hover { color: var(--accent-light); }
+    .topbar-right { display: flex; align-items: center; gap: 0.85rem; }
+    .topbar-right .ghlink { color: var(--text-dim); font-size: 0.9rem; font-weight: 500; }
+    .topbar-right .ghlink:hover { color: var(--accent-light); }
+    .theme-toggle { background: var(--surface-2); border: 1px solid var(--border);
+      color: var(--text); border-radius: var(--radius); padding: 0.35rem 0.6rem;
+      font-size: 0.95rem; cursor: pointer; line-height: 1; transition: border-color 0.15s, background 0.15s; }
+    .theme-toggle:hover { border-color: var(--accent-light); }
+
+    header.hero { max-width: var(--maxw); margin: 0 auto; padding: 3rem 1.25rem 1.5rem; }
+    header.hero h1 { font-size: clamp(1.9rem, 4vw, 2.6rem); letter-spacing: -0.02em; line-height: 1.15; }
+    header.hero p { color: var(--text-dim); max-width: 62ch; margin-top: 0.6rem; font-size: 1.02rem; }
+
+    /* ---- index: filter chips ---- */
+    .chips { max-width: var(--maxw); margin: 0 auto; padding: 0 1.25rem 0.25rem;
+      display: flex; flex-wrap: wrap; gap: 0.5rem; }
+    .chip { background: var(--surface-2); border: 1px solid var(--border); color: var(--text-dim);
+      border-radius: 999px; padding: 0.25rem 0.85rem; font-size: 0.82rem; font-weight: 500;
+      font-family: var(--font-sans); cursor: pointer; transition: color 0.15s, border-color 0.15s; }
+    .chip:hover { color: var(--accent-light); border-color: var(--accent); }
+    .chip.active { color: #fff; background: var(--accent); border-color: var(--accent); }
+
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem 1.25rem 2rem; }
+    .grid { display: grid; grid-template-columns: 1fr; gap: 1.5rem; align-items: stretch; }
+    .card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg);
+      overflow: hidden; display: flex; flex-direction: column;
+      transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease; }
+    .card:hover { transform: translateY(-3px); border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
+      box-shadow: 0 8px 28px rgba(0,0,0,0.28); }
+    .card.hidden { display: none; }
+    .card-media { display: block; background: var(--bg2); line-height: 0; }
+    .card-media img { display: block; width: 100%; aspect-ratio: 16 / 9; object-fit: cover; }
+    .card-body { padding: 1.15rem 1.4rem 1.45rem; display: flex; flex-direction: column; flex: 1 1 auto; }
+    .card-body h2 { font-size: 1.22rem; letter-spacing: -0.01em; margin-bottom: 0.5rem; }
+    .card-body h2 a { color: var(--text); }
+    .card-body h2 a:hover { color: var(--accent-light); text-decoration: none; }
+    .teaches { color: var(--text); margin-bottom: 0.7rem; }
+    .witnesses { color: var(--text-dim); font-size: 0.9rem; margin-bottom: 1rem; }
+    .tag { display: inline-block; font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.06em;
+      color: var(--accent-light); border: 1px solid color-mix(in srgb, var(--accent) 60%, transparent);
+      border-radius: 999px; padding: 0.08rem 0.55rem; margin-right: 0.4rem; vertical-align: 1px; }
+    .card-link { font-weight: 600; font-size: 0.95rem; margin-top: auto; }
+
+    /* ---- detail page ---- */
+    .detail-hero { border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden;
+      background: var(--bg2); padding: 0; display: block; width: 100%; cursor: zoom-in; line-height: 0; }
+    .detail-hero img { display: block; width: 100%; aspect-ratio: 16 / 9; object-fit: cover; }
+    .zoom-hint { color: var(--text-dim); font-size: 0.78rem; margin-top: 0.4rem; }
+    .callout { border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
+      border-left: 3px solid var(--accent); border-radius: var(--radius);
+      background: color-mix(in srgb, var(--accent) 7%, var(--surface));
+      padding: 0.85rem 1.1rem; margin: 1.5rem 0; font-size: 0.95rem; }
+    .runline { display: flex; align-items: stretch; gap: 0.5rem; margin: 1.5rem 0; }
+    .runline pre { flex: 1 1 auto; background: var(--surface-2); border: 1px solid var(--border);
+      border-radius: var(--radius); padding: 0.7rem 0.9rem; overflow-x: auto;
+      font-family: var(--font-mono); font-size: 0.83rem; line-height: 1.5; }
+    .copy-btn { flex: 0 0 auto; background: var(--surface-2); border: 1px solid var(--border);
+      color: var(--text-dim); border-radius: var(--radius); padding: 0 0.85rem; cursor: pointer;
+      font-family: var(--font-sans); font-size: 0.82rem; font-weight: 500; transition: color 0.15s, border-color 0.15s; }
+    .copy-btn:hover { color: var(--accent-light); border-color: var(--accent); }
+    .detail-section { margin-top: 2.25rem; }
+    .detail-section > h2 { font-size: 1.15rem; letter-spacing: -0.01em; padding-bottom: 0.5rem;
+      border-bottom: 1px solid var(--border); margin-bottom: 1rem; }
+
+    .md h1, .md h2, .md h3 { letter-spacing: -0.01em; margin: 1.4rem 0 0.6rem; line-height: 1.25; }
+    .md h1 { font-size: 1.35rem; } .md h2 { font-size: 1.15rem; } .md h3 { font-size: 1rem; }
+    .md p { margin: 0.7rem 0; }
+    .md ul { margin: 0.7rem 0 0.7rem 1.4rem; }
+    .md li { margin: 0.3rem 0; }
+    .md code { background: var(--surface-2); border: 1px solid var(--border); padding: 0.08rem 0.35rem;
+      border-radius: 4px; font-family: var(--font-mono); font-size: 0.84em; }
+    .md pre { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius);
+      padding: 0.85rem 1rem; overflow-x: auto; margin: 0.9rem 0; }
+    .md pre code { background: none; border: none; padding: 0; font-size: 0.83rem; line-height: 1.55; }
+
+    .src pre { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius);
+      padding: 1rem 1.1rem; overflow-x: auto; font-family: var(--font-mono);
+      font-size: 0.82rem; line-height: 1.55; }
+    .src .k { color: var(--code-k); } .src .s { color: var(--code-s); }
+    .src .c { color: var(--code-c); font-style: italic; } .src .n { color: var(--code-n); }
+    .src-meta { display: flex; justify-content: space-between; align-items: baseline; gap: 1rem;
+      flex-wrap: wrap; margin-bottom: 0.6rem; color: var(--text-dim); font-size: 0.85rem; }
+    .src-meta code { font-family: var(--font-mono); font-size: 0.82rem; }
+
+    .lightbox { position: fixed; inset: 0; z-index: 50; display: none; align-items: center;
+      justify-content: center; background: rgba(0,0,0,0.85); padding: 2rem; cursor: zoom-out; }
+    .lightbox.open { display: flex; }
+    .lightbox img { max-width: 100%; max-height: 100%; border-radius: var(--radius); }
+
+    footer { max-width: var(--maxw); margin: 0 auto; padding: 2rem 1.25rem 3rem;
+      color: var(--text-dim); font-size: 0.85rem; border-top: 1px solid var(--border); }
+    footer code { background: var(--surface-2); padding: 0.1rem 0.35rem; border-radius: 4px; font-size: 0.82rem; }
+
+    @media (min-width: 720px) { .grid { grid-template-columns: 1fr 1fr; gap: 1.75rem; } }
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+      .card, .theme-toggle { transition: none; }
+      .card:hover { transform: none; }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip" href="#main">Skip to content</a>
+  <div class="topbar">
+    <a class="back" href="../"><span aria-hidden="true">&larr;</span> Examples Gallery</a>
+    <div class="topbar-right">
+      <a class="ghlink" href="https://github.com/TMHSDigital/Blender-Developer-Tools">GitHub</a>
+      <button class="theme-toggle" id="themeToggle" type="button" aria-label="Theme: auto (click to change)">&#9788;</button>
+    </div>
+  </div>
+  <header class="hero">
+    <h1>turntable</h1>
+    <p>A slotted-actions Z-rotation turntable keyed through the cross-version channelbag path (get_channelbag_for_slot).</p>
+  </header>
+  <main id="main">
+    <button class="detail-hero" id="heroZoom" type="button" aria-label="Zoom turntable render">
+      <img src="../assets/turntable-hero.webp" alt="turntable render" width="1280" height="720" />
+    </button>
+    <p class="zoom-hint">Rendered headless by the example itself — click to zoom.</p>
+    <div class="callout"><span class="tag">witnesses</span> Slotted-actions boundary: ensure-helper channelbag on 5.x, strip.channelbag on 4.4/4.5.</div>
+    <div class="runline">
+      <pre id="runCmd">blender --background --python examples/turntable/turntable.py --</pre>
+      <button class="copy-btn" id="copyRun" type="button">Copy</button>
+    </div>
+    <section class="detail-section md">
+<p>A runnable example that keyframes a Z-rotation turntable through the <strong>slotted-actions</strong> cross-version channelbag path from the <a href="https://github.com/TMHSDigital/Blender-Developer-Tools/tree/main/skills/slotted-actions-animation/SKILL.md"><code>slotted-actions-animation</code></a> skill, and picks the render engine with the version-branch EEVEE-id helper.</p>
+<p><strong>Which fix it witnesses:</strong> the slotted-actions cross-version helper. On Blender 5.x the channelbag comes from <code>action_ensure_channelbag_for_slot</code>; on 4.4/4.5 from <code>strip.channelbag(slot, ensure=True)</code> (legacy <code>action.fcurves</code> still works on 4.5, raises <code>AttributeError</code> on 5.x).</p>
+<h2>Run</h2>
+<pre><code># Cheap correctness check only (no render) — the CI smoke check:
+blender --background --python turntable.py --
+
+# Also render one still (EEVEE on a GPU host; use --engine cycles on GPU-less hosts):
+blender --background --python turntable.py -- --output turntable.png
+blender --background --python turntable.py -- --output turntable.png --engine cycles</code></pre>
+<p>By default it runs only the <strong>frame-independent correctness check</strong>: it inserts the rotation keys, samples the object&#x27;s Z rotation at frame 1 vs a later frame, and asserts they <strong>differ</strong> (the keys drive playback). It exits non-zero on failure — the same check the <code>blender-smoke</code> workflow runs on Blender 4.5 LTS and 5.1. <code>--output</code> additionally renders a still; the full animated loop is a showcase extra, not part of the CI check.</p>
+    </section>
+    <section class="detail-section src">
+      <h2>Source</h2>
+      <div class="src-meta">
+        <code>examples/turntable/turntable.py</code>
+        <a href="https://github.com/TMHSDigital/Blender-Developer-Tools/tree/main/examples/turntable/turntable.py">View on GitHub &rarr;</a>
+      </div>
+      <pre><span class="s">&quot;&quot;&quot;Slotted-actions turntable -- a runnable BDT example.
+
+Keyframes a Z-rotation turntable through the slotted-actions cross-version channelbag path
+(`get_channelbag_for_slot`) and selects the engine with the version-branch EEVEE-id helper.
+It witnesses the slotted-actions fix: on Blender 5.x the channelbag comes from
+`action_ensure_channelbag_for_slot`; on 4.4/4.5 from `strip.channelbag(slot, ensure=True)`.
+
+By default it runs only the cheap, frame-independent correctness check (no render): insert
+the rotation keys, sample the object&#x27;s Z rotation at frame 1 vs a later frame, and assert
+they DIFFER -- proving the keys drive playback. Exits non-zero on failure. This is the check
+the CI smoke gate runs on both builds.
+
+    blender --background --python turntable.py --                 # correctness check only
+    blender --background --python turntable.py -- --output t.png  # also render one still
+    blender --background --python turntable.py -- --output t.png --engine cycles  # GPU-less
+&quot;&quot;&quot;</span>
+<span class="k">import</span> bpy, sys, os, math, argparse
+
+FRAMES = <span class="n">36</span>
+
+<span class="k">def</span> get_eevee_engine_id():
+    <span class="k">return</span> <span class="s">&#x27;BLENDER_EEVEE&#x27;</span> <span class="k">if</span> bpy.app.version &gt;= (<span class="n">5</span>, <span class="n">0</span>, <span class="n">0</span>) <span class="k">else</span> <span class="s">&#x27;BLENDER_EEVEE_NEXT&#x27;</span>
+
+<span class="k">def</span> get_channelbag_for_slot(action, slot):
+    <span class="k">if</span> bpy.app.version &gt;= (<span class="n">5</span>, <span class="n">0</span>, <span class="n">0</span>):
+        <span class="k">from</span> bpy_extras.anim_utils <span class="k">import</span> action_ensure_channelbag_for_slot
+        <span class="k">return</span> action_ensure_channelbag_for_slot(action, slot)
+    layer = action.layers[<span class="n">0</span>] <span class="k">if</span> action.layers <span class="k">else</span> action.layers.new(<span class="s">&quot;Layer&quot;</span>)
+    strip = layer.strips[<span class="n">0</span>] <span class="k">if</span> layer.strips <span class="k">else</span> layer.strips.new(type=<span class="s">&#x27;KEYFRAME&#x27;</span>)
+    <span class="k">return</span> strip.channelbag(slot, ensure=<span class="k">True</span>)
+
+<span class="k">def</span> build():
+    bpy.ops.wm.read_factory_settings(use_empty=<span class="k">True</span>)
+    bpy.ops.mesh.primitive_monkey_add(location=(<span class="n">0</span>, <span class="n">0</span>, <span class="n">1.0</span>))
+    obj = bpy.context.active_object
+    <span class="k">for</span> p <span class="k">in</span> obj.data.polygons:
+        p.use_smooth = <span class="k">True</span>
+    mat = bpy.data.materials.new(<span class="s">&quot;M&quot;</span>); mat.use_nodes = <span class="k">True</span>
+    b = mat.node_tree.nodes.get(<span class="s">&#x27;Principled BSDF&#x27;</span>)
+    b.inputs[<span class="s">&#x27;Base Color&#x27;</span>].default_value = (<span class="n">0.85</span>, <span class="n">0.35</span>, <span class="n">0.10</span>, <span class="n">1</span>)
+    b.inputs[<span class="s">&#x27;Metallic&#x27;</span>].default_value = <span class="n">0.7</span>
+    b.inputs[<span class="s">&#x27;Roughness&#x27;</span>].default_value = <span class="n">0.25</span>
+    obj.data.materials.append(mat)
+    <span class="c"># rotation keyframes via the slotted-actions channelbag path</span>
+    obj.animation_data_create()
+    act = bpy.data.actions.new(<span class="s">&quot;Turn&quot;</span>); obj.animation_data.action = act
+    slot = obj.animation_data.action_slot
+    <span class="k">if</span> slot <span class="k">is</span> <span class="k">None</span>:
+        slot = act.slots.new(id_type=<span class="s">&#x27;OBJECT&#x27;</span>, name=obj.name); obj.animation_data.action_slot = slot
+    cbag = get_channelbag_for_slot(act, slot)
+    fc = cbag.fcurves.new(<span class="s">&quot;rotation_euler&quot;</span>, index=<span class="n">2</span>)
+    fc.keyframe_points.insert(<span class="n">1</span>, <span class="n">0.0</span>)
+    fc.keyframe_points.insert(FRAMES, math.radians(<span class="n">360</span>))
+    <span class="k">for</span> kp <span class="k">in</span> fc.keyframe_points:
+        kp.interpolation = <span class="s">&#x27;LINEAR&#x27;</span>
+    fc.update()
+    <span class="k">return</span> obj
+
+<span class="k">def</span> correctness(obj):
+    sc = bpy.context.scene; sc.frame_start = <span class="n">1</span>; sc.frame_end = FRAMES
+    <span class="k">def</span> rz(f):
+        sc.frame_set(f); dg = bpy.context.evaluated_depsgraph_get()
+        <span class="k">return</span> round(obj.evaluated_get(dg).rotation_euler.z, <span class="n">4</span>)
+    r1, rmid, rend = rz(<span class="n">1</span>), rz(FRAMES // <span class="n">2</span>), rz(FRAMES)
+    branch = <span class="s">&#x27;5.0+ ensure-helper&#x27;</span> <span class="k">if</span> bpy.app.version &gt;= (<span class="n">5</span>, <span class="n">0</span>, <span class="n">0</span>) <span class="k">else</span> <span class="s">&#x27;4.4/4.5 strip.channelbag&#x27;</span>
+    drives = (r1 != rmid != rend) <span class="k">and</span> abs(rend - r1) &gt; <span class="n">0.5</span>
+    print(<span class="s">f&quot;</span><span class="s">branch=</span>{branch}<span class="s"> rot_z f1=</span>{r1}<span class="s"> fmid=</span>{rmid}<span class="s"> fend=</span>{rend}<span class="s"> drives=</span>{drives}<span class="s">&quot;</span>)
+    <span class="k">return</span> drives
+
+<span class="k">def</span> render_still(obj, path, engine):
+    <span class="k">import</span> bmesh
+    sc = bpy.context.scene
+    fme = bpy.data.meshes.new(<span class="s">&quot;Floor&quot;</span>); bm = bmesh.new()
+    bmesh.ops.create_grid(bm, x_segments=<span class="n">1</span>, y_segments=<span class="n">1</span>, size=<span class="n">30.0</span>); bm.to_mesh(fme); bm.free()
+    floor = bpy.data.objects.new(<span class="s">&quot;Floor&quot;</span>, fme); bpy.context.collection.objects.link(floor)
+    w = bpy.data.worlds.new(<span class="s">&quot;W&quot;</span>); w.use_nodes = <span class="k">True</span>
+    w.node_tree.nodes[<span class="s">&quot;Background&quot;</span>].inputs[<span class="n">0</span>].default_value = (<span class="n">0.04</span>, <span class="n">0.05</span>, <span class="n">0.07</span>, <span class="n">1</span>); sc.world = w
+    aim = bpy.data.objects.new(<span class="s">&quot;Aim&quot;</span>, <span class="k">None</span>); aim.location = (<span class="n">0</span>, <span class="n">0</span>, <span class="n">1.0</span>); bpy.context.collection.objects.link(aim)
+    cam = bpy.data.objects.new(<span class="s">&quot;cam&quot;</span>, bpy.data.cameras.new(<span class="s">&quot;cam&quot;</span>)); cam.location = (<span class="n">0</span>, -<span class="n">7</span>, <span class="n">3.0</span>)
+    bpy.context.collection.objects.link(cam); sc.camera = cam
+    c = cam.constraints.new(<span class="s">&#x27;TRACK_TO&#x27;</span>); c.target = aim; c.track_axis = <span class="s">&#x27;TRACK_NEGATIVE_Z&#x27;</span>; c.up_axis = <span class="s">&#x27;UP_Y&#x27;</span>
+    <span class="k">for</span> nm, loc, en <span class="k">in</span> [(<span class="s">&quot;K&quot;</span>, (-<span class="n">4</span>, -<span class="n">5</span>, <span class="n">7</span>), <span class="n">900</span>), (<span class="s">&quot;F2&quot;</span>, (<span class="n">5</span>, -<span class="n">4</span>, <span class="n">2</span>), <span class="n">350</span>)]:
+        ld = bpy.data.lights.new(nm, <span class="s">&#x27;AREA&#x27;</span>); ld.energy = en; ld.size = <span class="n">5.0</span>
+        lo = bpy.data.objects.new(nm, ld); lo.location = loc; bpy.context.collection.objects.link(lo)
+        lc = lo.constraints.new(<span class="s">&#x27;TRACK_TO&#x27;</span>); lc.target = aim; lc.track_axis = <span class="s">&#x27;TRACK_NEGATIVE_Z&#x27;</span>; lc.up_axis = <span class="s">&#x27;UP_Y&#x27;</span>
+    sc.render.engine = <span class="s">&#x27;CYCLES&#x27;</span> <span class="k">if</span> engine == <span class="s">&#x27;cycles&#x27;</span> <span class="k">else</span> get_eevee_engine_id()
+    <span class="k">if</span> sc.render.engine == <span class="s">&#x27;CYCLES&#x27;</span>:
+        <span class="k">try</span>: sc.cycles.samples = <span class="n">16</span>
+        <span class="k">except</span> Exception: <span class="k">pass</span>
+    <span class="k">else</span>:
+        <span class="k">try</span>: sc.eevee.taa_render_samples = <span class="n">16</span>
+        <span class="k">except</span> Exception: <span class="k">pass</span>
+    sc.frame_set(FRAMES // <span class="n">4</span>)
+    sc.render.resolution_x = <span class="n">1280</span>; sc.render.resolution_y = <span class="n">720</span>
+    sc.render.image_settings.file_format = <span class="s">&#x27;PNG&#x27;</span>; sc.render.filepath = path
+    bpy.ops.render.render(write_still=<span class="k">True</span>)
+    <span class="k">return</span> os.path.exists(path) <span class="k">and</span> os.path.getsize(path) &gt; <span class="n">0</span>
+
+<span class="k">def</span> main():
+    argv = sys.argv[sys.argv.index(<span class="s">&quot;--&quot;</span>) + <span class="n">1</span>:] <span class="k">if</span> <span class="s">&quot;--&quot;</span> <span class="k">in</span> sys.argv <span class="k">else</span> []
+    p = argparse.ArgumentParser()
+    p.add_argument(<span class="s">&quot;--output&quot;</span>, default=<span class="k">None</span>, help=<span class="s">&quot;optional: render one still to this PNG&quot;</span>)
+    p.add_argument(<span class="s">&quot;--engine&quot;</span>, choices=[<span class="s">&quot;auto&quot;</span>, <span class="s">&quot;cycles&quot;</span>], default=<span class="s">&quot;auto&quot;</span>)
+    args = p.parse_args(argv)
+
+    <span class="c"># the EEVEE-id mapping is asserted regardless of whether we render</span>
+    eid = get_eevee_engine_id()
+    expected = <span class="s">&#x27;BLENDER_EEVEE&#x27;</span> <span class="k">if</span> bpy.app.version &gt;= (<span class="n">5</span>, <span class="n">0</span>, <span class="n">0</span>) <span class="k">else</span> <span class="s">&#x27;BLENDER_EEVEE_NEXT&#x27;</span>
+    bpy.context.scene.render.engine = eid
+    <span class="k">if</span> bpy.context.scene.render.engine != expected:
+        print(<span class="s">f&quot;</span><span class="s">ERROR: EEVEE id </span>{eid}<span class="s"> != expected </span>{expected}<span class="s">&quot;</span>, file=sys.stderr); <span class="k">return</span> <span class="n">5</span>
+
+    obj = build()
+    <span class="k">if</span> <span class="k">not</span> correctness(obj):
+        print(<span class="s">&quot;ERROR: rotation keys do not drive playback&quot;</span>, file=sys.stderr); <span class="k">return</span> <span class="n">3</span>
+
+    <span class="k">if</span> args.output:
+        <span class="k">if</span> <span class="k">not</span> render_still(obj, args.output, args.engine):
+            print(<span class="s">&quot;ERROR: still render produced no file&quot;</span>, file=sys.stderr); <span class="k">return</span> <span class="n">4</span>
+        print(<span class="s">f&quot;</span><span class="s">rendered still </span>{args.output}<span class="s"> (</span>{os.path.getsize(args.output)}<span class="s"> bytes)</span><span class="s">&quot;</span>)
+    print(<span class="s">&quot;turntable OK&quot;</span>)
+    <span class="k">return</span> <span class="n">0</span>
+
+<span class="k">if</span> __name__ == <span class="s">&quot;__main__&quot;</span>:
+    <span class="k">try</span>:
+        sys.exit(main())
+    <span class="k">except</span> Exception <span class="k">as</span> exc:
+        <span class="k">import</span> traceback; traceback.print_exc()
+        print(<span class="s">f&quot;</span><span class="s">FATAL: </span>{type(exc).__name__}<span class="s">: </span>{exc}<span class="s">&quot;</span>, file=sys.stderr); sys.exit(<span class="n">1</span>)
+</pre>
+    </section>
+  </main>
+  <div class="lightbox" id="lightbox" role="dialog" aria-label="Full-size render">
+    <img src="../assets/turntable-hero.webp" alt="turntable render, full size" />
+  </div>
+  <footer>
+    Generated from <code>examples/gallery.json</code> by <code>scripts/build_gallery.py</code>.
+    &nbsp;&bull;&nbsp; CC-BY-NC-ND-4.0
+  </footer>
+  <script>
+    (function () {
+      var btn = document.getElementById('themeToggle');
+      var root = document.documentElement;
+      var order = ['auto', 'light', 'dark'];
+      var glyph = { auto: '\u263C', light: '\u2600', dark: '\u263D' };
+      function get() { try { return localStorage.getItem('theme') || 'auto'; } catch (e) { return 'auto'; } }
+      function apply(state) {
+        if (state === 'light' || state === 'dark') root.setAttribute('data-theme', state);
+        else root.removeAttribute('data-theme');
+        try { if (state === 'auto') localStorage.removeItem('theme'); else localStorage.setItem('theme', state); } catch (e) {}
+        btn.innerHTML = glyph[state]; btn.setAttribute('aria-label', 'Theme: ' + state + ' (click to change)');
+      }
+      apply(get());
+      btn.addEventListener('click', function () {
+        var next = order[(order.indexOf(get()) + 1) % order.length];
+        apply(next);
+      });
+    })();
+
+    (function () {
+      var hero = document.getElementById('heroZoom');
+      var box = document.getElementById('lightbox');
+      if (hero && box) {
+        hero.addEventListener('click', function () { box.classList.add('open'); });
+        box.addEventListener('click', function () { box.classList.remove('open'); });
+        document.addEventListener('keydown', function (e) {
+          if (e.key === 'Escape') box.classList.remove('open');
+        });
+      }
+      var copy = document.getElementById('copyRun');
+      if (copy) {
+        copy.addEventListener('click', function () {
+          var cmd = document.getElementById('runCmd').textContent;
+          navigator.clipboard.writeText(cmd).then(function () {
+            copy.textContent = 'Copied!';
+            setTimeout(function () { copy.textContent = 'Copy'; }, 1500);
+          });
+        });
+      }
+    })();
+
+  </script>
+</body>
+</html>

--- a/examples/gallery.json
+++ b/examples/gallery.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "FORWARD-COMPATIBLE SOURCE OF TRUTH for the examples gallery. The local page at docs/gallery/index.html is GENERATED from this file by scripts/build_gallery.py -- do not hand-edit the HTML. When the fleet template (Developer-Tools-Directory: site-template/build_site.py + template.html.j2) gains examples support (see ROADMAP: 'Fleet Pages examples support'), it reads this same file and the local page is retired. That migration is a lift-and-shift, not a rewrite: keep this schema stable. Per-entry schema: {name, dir, teaches, witnessesFix, hero, preview}; hero/preview/dir are repo-root-relative.",
+  "_comment": "FORWARD-COMPATIBLE SOURCE OF TRUTH for the examples gallery. The local page at docs/gallery/index.html is GENERATED from this file by scripts/build_gallery.py -- do not hand-edit the HTML. When the fleet template (Developer-Tools-Directory: site-template/build_site.py + template.html.j2) gains examples support (see ROADMAP: 'Fleet Pages examples support'), it reads this same file and the local page is retired. That migration is a lift-and-shift, not a rewrite: keep this schema stable. Per-entry schema: {name, dir, teaches, witnessesFix, hero, preview, tags?}; hero/preview/dir are repo-root-relative; tags is an optional additive list driving the gallery filter chips. build_gallery.py also emits a detail page per example at docs/gallery/<name>/.",
   "title": "Examples Gallery",
   "description": "Runnable, smoke-gated Blender Python examples — each executed headless on Blender 4.5 LTS and 5.1, so every render reflects code that actually runs.",
   "repoBaseUrl": "https://github.com/TMHSDigital/Blender-Developer-Tools/tree/main",
@@ -11,7 +11,8 @@
       "teaches": "Procedural Principled materials — metal and dielectric, the emission pattern, and the cross-version set_specular shim.",
       "witnessesFix": "EEVEE engine-id mapping: BLENDER_EEVEE on 5.x, BLENDER_EEVEE_NEXT on 4.2–4.5.",
       "hero": "docs/gallery/assets/swatch-grid-hero.webp",
-      "preview": "examples/swatch-grid/preview.webp"
+      "preview": "examples/swatch-grid/preview.webp",
+      "tags": ["materials", "rendering"]
     },
     {
       "name": "turntable",
@@ -19,7 +20,8 @@
       "teaches": "A slotted-actions Z-rotation turntable keyed through the cross-version channelbag path (get_channelbag_for_slot).",
       "witnessesFix": "Slotted-actions boundary: ensure-helper channelbag on 5.x, strip.channelbag on 4.4/4.5.",
       "hero": "docs/gallery/assets/turntable-hero.webp",
-      "preview": "examples/turntable/preview.webp"
+      "preview": "examples/turntable/preview.webp",
+      "tags": ["animation"]
     },
     {
       "name": "gn-sdf-remesh",
@@ -27,7 +29,8 @@
       "teaches": "A Geometry Nodes SDF remesh (MeshToSDFGrid → GridToMesh at the SDF zero-level), with a Set Material node carrying the material through the remesh.",
       "witnessesFix": "An SDF grid is meshed with Grid to Mesh, not Volume to Mesh; GN geometry needs Set Material or it renders untextured.",
       "hero": "docs/gallery/assets/gn-sdf-remesh-hero.webp",
-      "preview": "examples/gn-sdf-remesh/preview.webp"
+      "preview": "examples/gn-sdf-remesh/preview.webp",
+      "tags": ["geometry-nodes", "materials"]
     },
     {
       "name": "depsgraph-export",
@@ -35,7 +38,8 @@
       "teaches": "The depsgraph lifetime contract — evaluated_get().to_mesh() paired with to_mesh_clear() — measured against an OBJ export of the same object.",
       "witnessesFix": "Exports ship evaluated geometry: the exported vertex count equals the subsurf-applied count and is strictly greater than the base mesh.",
       "hero": "docs/gallery/assets/depsgraph-export-hero.webp",
-      "preview": "examples/depsgraph-export/preview.webp"
+      "preview": "examples/depsgraph-export/preview.webp",
+      "tags": ["depsgraph", "export"]
     }
   ]
 }

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -1,64 +1,67 @@
 #!/usr/bin/env python3
-"""Generate the standalone examples gallery page from examples/gallery.json.
+"""Generate the examples gallery from examples/gallery.json.
 
-This page is a LOCAL, this-repo gallery that rides alongside the fleet-generated
-docs/index.html (which build_site.py owns and overwrites). It writes ONLY to
-docs/gallery/ so it never collides with the fleet build's docs/index.html,
-docs/fonts/, or docs/assets/.
+Emits the gallery index (docs/gallery/index.html) AND one detail page per
+example (docs/gallery/<name>/index.html) with the hero render (click to
+zoom), a run-it-yourself command, the example's README rendered inline, and
+the full Python source syntax-highlighted at build time.
 
-examples/gallery.json is the forward-compatible source of truth: when the fleet
-template gains examples support, it consumes the same data and this script and
-page are retired. The visual direction here is the deliberate PROTOTYPE for that
-fleet facelift -- see docs/gallery/DESIGN_NOTES.md. Run after editing gallery.json:
+This is a LOCAL, this-repo gallery that rides alongside the generated
+docs/index.html (which scripts/site/build_site.py owns and overwrites). It
+writes ONLY under docs/gallery/ so it never collides with the landing build's
+docs/index.html, docs/fonts/, or docs/assets/.
+
+examples/gallery.json is the source of truth. Run after editing gallery.json,
+an example script, or an example README:
 
     python scripts/build_gallery.py
 
-Stdlib only (no Jinja2), so the Pages workflow can regenerate it without extra deps.
-Uses token replacement (not str.format) so CSS braces need no escaping.
+Stdlib only (no Jinja2, no Pygments), so the Pages workflow can regenerate it
+without extra deps. Uses token replacement (not str.format) so CSS braces
+need no escaping.
 """
 import html
+import io
 import json
+import keyword
+import posixpath
+import re
 import sys
+import tokenize
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 DATA = REPO / "examples" / "gallery.json"
-OUT = REPO / "docs" / "gallery" / "index.html"
+OUT_DIR = REPO / "docs" / "gallery"
 
-CARD = """      <article class="card">
-        <a class="card-media" href="__HREF__" aria-label="__NAME__ example on GitHub">
-          <img src="__HERO__" alt="__ALT__" loading="lazy" decoding="async" />
-        </a>
-        <div class="card-body">
-          <h2><a href="__HREF__">__NAME__</a></h2>
-          <p class="teaches">__TEACHES__</p>
-          <p class="witnesses"><span class="tag">witnesses</span> __WITNESSES__</p>
-          <a class="card-link" href="__HREF__">View example <span aria-hidden="true">&rarr;</span></a>
-        </div>
-      </article>"""
+# ---------------------------------------------------------------------------
+# Shared page shell. __ROOT__ is the relative prefix from the page to the
+# gallery root ("" for the index, "../" for detail pages); __SITEROOT__ is the
+# prefix to the site root ("../" for the index, "../../" for detail pages).
+# ---------------------------------------------------------------------------
 
-PAGE = """<!DOCTYPE html>
+SHELL = """<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>__TITLE__ — Blender Developer Tools</title>
+  <title>__TITLE__</title>
   <meta name="description" content="__DESC__" />
   <link rel="canonical" href="__CANONICAL__" />
-  <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml" />
+  <link rel="icon" href="__SITEROOT__assets/favicon.svg" type="image/svg+xml" />
   <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)" />
   <meta name="theme-color" content="#f6f8fa" media="(prefers-color-scheme: light)" />
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="__TITLE__ — Blender Developer Tools" />
+  <meta property="og:title" content="__TITLE__" />
   <meta property="og:description" content="__DESC__" />
   <meta property="og:url" content="__CANONICAL__" />
   <meta property="og:image" content="__OGIMAGE__" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="__TITLE__ — Blender Developer Tools" />
+  <meta name="twitter:title" content="__TITLE__" />
   <meta name="twitter:description" content="__DESC__" />
   <meta name="twitter:image" content="__OGIMAGE__" />
   <!-- FOUC guard: apply the saved theme before first paint. Shares the 'theme'
-       key with the fleet landing page, so a visitor's choice carries across. -->
+       key with the landing page, so a visitor's choice carries across. -->
   <script>(function(){try{var t=localStorage.getItem('theme');if(t==='light'||t==='dark')document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
   <style>
     :root {
@@ -67,18 +70,22 @@ PAGE = """<!DOCTYPE html>
       --accent: #7c3aed; --accent-light: #a78bfa;
       --radius: 8px; --radius-lg: 12px; --maxw: 1080px;
       --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+      --font-mono: ui-monospace, 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
+      --code-k: #ff7b72; --code-s: #a5d6ff; --code-c: #8b949e; --code-n: #79c0ff;
     }
     /* auto mode: follow the OS unless the user forced dark */
     @media (prefers-color-scheme: light) {
       :root:not([data-theme="dark"]) {
         --bg: #f6f8fa; --bg2: #ffffff; --surface: #ffffff; --surface-2: #f0f2f5;
         --border: #d0d7de; --text: #1f2328; --text-dim: #656d76;
+        --code-k: #cf222e; --code-s: #0a3069; --code-c: #6e7781; --code-n: #0550ae;
       }
     }
     /* explicit override */
     [data-theme="light"] {
       --bg: #f6f8fa; --bg2: #ffffff; --surface: #ffffff; --surface-2: #f0f2f5;
       --border: #d0d7de; --text: #1f2328; --text-dim: #656d76;
+      --code-k: #cf222e; --code-s: #0a3069; --code-c: #6e7781; --code-n: #0550ae;
     }
     * { box-sizing: border-box; margin: 0; padding: 0; }
     html { scroll-behavior: smooth; }
@@ -109,13 +116,23 @@ PAGE = """<!DOCTYPE html>
     header.hero h1 { font-size: clamp(1.9rem, 4vw, 2.6rem); letter-spacing: -0.02em; line-height: 1.15; }
     header.hero p { color: var(--text-dim); max-width: 62ch; margin-top: 0.6rem; font-size: 1.02rem; }
 
-    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem 1.25rem 2rem;
-      display: grid; grid-template-columns: 1fr; gap: 1.5rem; align-items: stretch; }
+    /* ---- index: filter chips ---- */
+    .chips { max-width: var(--maxw); margin: 0 auto; padding: 0 1.25rem 0.25rem;
+      display: flex; flex-wrap: wrap; gap: 0.5rem; }
+    .chip { background: var(--surface-2); border: 1px solid var(--border); color: var(--text-dim);
+      border-radius: 999px; padding: 0.25rem 0.85rem; font-size: 0.82rem; font-weight: 500;
+      font-family: var(--font-sans); cursor: pointer; transition: color 0.15s, border-color 0.15s; }
+    .chip:hover { color: var(--accent-light); border-color: var(--accent); }
+    .chip.active { color: #fff; background: var(--accent); border-color: var(--accent); }
+
+    main { max-width: var(--maxw); margin: 0 auto; padding: 1rem 1.25rem 2rem; }
+    .grid { display: grid; grid-template-columns: 1fr; gap: 1.5rem; align-items: stretch; }
     .card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg);
       overflow: hidden; display: flex; flex-direction: column;
       transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease; }
     .card:hover { transform: translateY(-3px); border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
       box-shadow: 0 8px 28px rgba(0,0,0,0.28); }
+    .card.hidden { display: none; }
     .card-media { display: block; background: var(--bg2); line-height: 0; }
     .card-media img { display: block; width: 100%; aspect-ratio: 16 / 9; object-fit: cover; }
     .card-body { padding: 1.15rem 1.4rem 1.45rem; display: flex; flex-direction: column; flex: 1 1 auto; }
@@ -129,11 +146,57 @@ PAGE = """<!DOCTYPE html>
       border-radius: 999px; padding: 0.08rem 0.55rem; margin-right: 0.4rem; vertical-align: 1px; }
     .card-link { font-weight: 600; font-size: 0.95rem; margin-top: auto; }
 
+    /* ---- detail page ---- */
+    .detail-hero { border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden;
+      background: var(--bg2); padding: 0; display: block; width: 100%; cursor: zoom-in; line-height: 0; }
+    .detail-hero img { display: block; width: 100%; aspect-ratio: 16 / 9; object-fit: cover; }
+    .zoom-hint { color: var(--text-dim); font-size: 0.78rem; margin-top: 0.4rem; }
+    .callout { border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
+      border-left: 3px solid var(--accent); border-radius: var(--radius);
+      background: color-mix(in srgb, var(--accent) 7%, var(--surface));
+      padding: 0.85rem 1.1rem; margin: 1.5rem 0; font-size: 0.95rem; }
+    .runline { display: flex; align-items: stretch; gap: 0.5rem; margin: 1.5rem 0; }
+    .runline pre { flex: 1 1 auto; background: var(--surface-2); border: 1px solid var(--border);
+      border-radius: var(--radius); padding: 0.7rem 0.9rem; overflow-x: auto;
+      font-family: var(--font-mono); font-size: 0.83rem; line-height: 1.5; }
+    .copy-btn { flex: 0 0 auto; background: var(--surface-2); border: 1px solid var(--border);
+      color: var(--text-dim); border-radius: var(--radius); padding: 0 0.85rem; cursor: pointer;
+      font-family: var(--font-sans); font-size: 0.82rem; font-weight: 500; transition: color 0.15s, border-color 0.15s; }
+    .copy-btn:hover { color: var(--accent-light); border-color: var(--accent); }
+    .detail-section { margin-top: 2.25rem; }
+    .detail-section > h2 { font-size: 1.15rem; letter-spacing: -0.01em; padding-bottom: 0.5rem;
+      border-bottom: 1px solid var(--border); margin-bottom: 1rem; }
+
+    .md h1, .md h2, .md h3 { letter-spacing: -0.01em; margin: 1.4rem 0 0.6rem; line-height: 1.25; }
+    .md h1 { font-size: 1.35rem; } .md h2 { font-size: 1.15rem; } .md h3 { font-size: 1rem; }
+    .md p { margin: 0.7rem 0; }
+    .md ul { margin: 0.7rem 0 0.7rem 1.4rem; }
+    .md li { margin: 0.3rem 0; }
+    .md code { background: var(--surface-2); border: 1px solid var(--border); padding: 0.08rem 0.35rem;
+      border-radius: 4px; font-family: var(--font-mono); font-size: 0.84em; }
+    .md pre { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius);
+      padding: 0.85rem 1rem; overflow-x: auto; margin: 0.9rem 0; }
+    .md pre code { background: none; border: none; padding: 0; font-size: 0.83rem; line-height: 1.55; }
+
+    .src pre { background: var(--surface-2); border: 1px solid var(--border); border-radius: var(--radius);
+      padding: 1rem 1.1rem; overflow-x: auto; font-family: var(--font-mono);
+      font-size: 0.82rem; line-height: 1.55; }
+    .src .k { color: var(--code-k); } .src .s { color: var(--code-s); }
+    .src .c { color: var(--code-c); font-style: italic; } .src .n { color: var(--code-n); }
+    .src-meta { display: flex; justify-content: space-between; align-items: baseline; gap: 1rem;
+      flex-wrap: wrap; margin-bottom: 0.6rem; color: var(--text-dim); font-size: 0.85rem; }
+    .src-meta code { font-family: var(--font-mono); font-size: 0.82rem; }
+
+    .lightbox { position: fixed; inset: 0; z-index: 50; display: none; align-items: center;
+      justify-content: center; background: rgba(0,0,0,0.85); padding: 2rem; cursor: zoom-out; }
+    .lightbox.open { display: flex; }
+    .lightbox img { max-width: 100%; max-height: 100%; border-radius: var(--radius); }
+
     footer { max-width: var(--maxw); margin: 0 auto; padding: 2rem 1.25rem 3rem;
       color: var(--text-dim); font-size: 0.85rem; border-top: 1px solid var(--border); }
     footer code { background: var(--surface-2); padding: 0.1rem 0.35rem; border-radius: 4px; font-size: 0.82rem; }
 
-    @media (min-width: 720px) { main { grid-template-columns: 1fr 1fr; gap: 1.75rem; } }
+    @media (min-width: 720px) { .grid { grid-template-columns: 1fr 1fr; gap: 1.75rem; } }
     @media (prefers-reduced-motion: reduce) {
       html { scroll-behavior: auto; }
       .card, .theme-toggle { transition: none; }
@@ -144,19 +207,13 @@ PAGE = """<!DOCTYPE html>
 <body>
   <a class="skip" href="#main">Skip to content</a>
   <div class="topbar">
-    <a class="back" href="../"><span aria-hidden="true">&larr;</span> Blender Developer Tools</a>
+    <a class="back" href="__BACKHREF__"><span aria-hidden="true">&larr;</span> __BACKLABEL__</a>
     <div class="topbar-right">
       <a class="ghlink" href="__REPO__">GitHub</a>
       <button class="theme-toggle" id="themeToggle" type="button" aria-label="Theme: auto (click to change)">&#9788;</button>
     </div>
   </div>
-  <header class="hero">
-    <h1>__TITLE__</h1>
-    <p>__DESC__</p>
-  </header>
-  <main id="main">
-__CARDS__
-  </main>
+__CONTENT__
   <footer>
     Generated from <code>examples/gallery.json</code> by <code>scripts/build_gallery.py</code>.
     &nbsp;&bull;&nbsp; CC-BY-NC-ND-4.0
@@ -180,16 +237,357 @@ __CARDS__
         apply(next);
       });
     })();
+__PAGEJS__
   </script>
 </body>
 </html>
 """
 
+INDEX_JS = """
+    (function () {
+      var chips = document.querySelectorAll('.chip');
+      var cards = document.querySelectorAll('.card');
+      chips.forEach(function (chip) {
+        chip.addEventListener('click', function () {
+          chips.forEach(function (c) { c.classList.remove('active'); });
+          chip.classList.add('active');
+          var tag = chip.getAttribute('data-tag');
+          cards.forEach(function (card) {
+            var tags = (card.getAttribute('data-tags') || '').split(' ');
+            card.classList.toggle('hidden', !!tag && tags.indexOf(tag) === -1);
+          });
+        });
+      });
+    })();
+"""
+
+DETAIL_JS = """
+    (function () {
+      var hero = document.getElementById('heroZoom');
+      var box = document.getElementById('lightbox');
+      if (hero && box) {
+        hero.addEventListener('click', function () { box.classList.add('open'); });
+        box.addEventListener('click', function () { box.classList.remove('open'); });
+        document.addEventListener('keydown', function (e) {
+          if (e.key === 'Escape') box.classList.remove('open');
+        });
+      }
+      var copy = document.getElementById('copyRun');
+      if (copy) {
+        copy.addEventListener('click', function () {
+          var cmd = document.getElementById('runCmd').textContent;
+          navigator.clipboard.writeText(cmd).then(function () {
+            copy.textContent = 'Copied!';
+            setTimeout(function () { copy.textContent = 'Copy'; }, 1500);
+          });
+        });
+      }
+    })();
+"""
+
+CARD = """      <article class="card" data-tags="__TAGS__">
+        <a class="card-media" href="__HREF__" aria-label="__NAME__ example detail page">
+          <img src="__HERO__" alt="__ALT__" loading="lazy" decoding="async" />
+        </a>
+        <div class="card-body">
+          <h2><a href="__HREF__">__NAME__</a></h2>
+          <p class="teaches">__TEACHES__</p>
+          <p class="witnesses"><span class="tag">witnesses</span> __WITNESSES__</p>
+          <a class="card-link" href="__HREF__">View example <span aria-hidden="true">&rarr;</span></a>
+        </div>
+      </article>"""
+
+
+# ---------------------------------------------------------------------------
+# Build-time Python syntax highlighting (stdlib tokenize; no Pygments).
+# ---------------------------------------------------------------------------
+
+_FSTRING_TYPES = {
+    getattr(tokenize, name, -1)
+    for name in ("FSTRING_START", "FSTRING_MIDDLE", "FSTRING_END")
+}
+
+
+def highlight_python(src: str) -> str:
+    """Return HTML for *src* with keyword/string/comment/number spans."""
+    line_starts = [0]
+    for line in src.splitlines(keepends=True):
+        line_starts.append(line_starts[-1] + len(line))
+
+    def offset(row: int, col: int) -> int:
+        return line_starts[row - 1] + col
+
+    out: list[str] = []
+    last = 0
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(src).readline):
+            start, end = offset(*tok.start), offset(*tok.end)
+            if start < last:  # overlapping synthetic token (NEWLINE/INDENT)
+                continue
+            if start > last:
+                out.append(html.escape(src[last:start]))
+            cls = None
+            if tok.type == tokenize.COMMENT:
+                cls = "c"
+            elif tok.type == tokenize.STRING or tok.type in _FSTRING_TYPES:
+                cls = "s"
+            elif tok.type == tokenize.NUMBER:
+                cls = "n"
+            elif tok.type == tokenize.NAME and keyword.iskeyword(tok.string):
+                cls = "k"
+            text = html.escape(src[start:end])
+            out.append(f'<span class="{cls}">{text}</span>' if cls and text else text)
+            last = end
+    except tokenize.TokenError:
+        return html.escape(src)
+    out.append(html.escape(src[last:]))
+    return "".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Markdown renderer for the example READMEs (headings, paragraphs,
+# unordered lists, fenced code, inline code/bold/links). Relative links are
+# resolved against the example's directory on GitHub.
+# ---------------------------------------------------------------------------
+
+_INLINE = re.compile(r"`([^`]+)`|\*\*(.+?)\*\*|\[([^\]]+)\]\(([^)]+)\)")
+
+
+def render_inline(text: str, resolve) -> str:
+    out = []
+    pos = 0
+    for m in _INLINE.finditer(text):
+        out.append(html.escape(text[pos:m.start()]))
+        if m.group(1) is not None:
+            out.append(f"<code>{html.escape(m.group(1))}</code>")
+        elif m.group(2) is not None:
+            out.append(f"<strong>{render_inline(m.group(2), resolve)}</strong>")
+        else:
+            href = html.escape(resolve(m.group(4)), quote=True)
+            out.append(f'<a href="{href}">{render_inline(m.group(3), resolve)}</a>')
+        pos = m.end()
+    out.append(html.escape(text[pos:]))
+    return "".join(out)
+
+
+def md_to_html(text: str, resolve, skip_first_h1: bool = True) -> str:
+    lines = text.splitlines()
+    out: list[str] = []
+    i = 0
+    seen_h1 = False
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+
+        if not stripped:
+            i += 1
+            continue
+
+        if stripped.startswith("```"):
+            code: list[str] = []
+            i += 1
+            while i < len(lines) and not lines[i].strip().startswith("```"):
+                code.append(lines[i])
+                i += 1
+            i += 1  # closing fence
+            out.append(f"<pre><code>{html.escape(chr(10).join(code))}</code></pre>")
+            continue
+
+        m = re.match(r"^(#{1,3})\s+(.*)$", stripped)
+        if m:
+            level = len(m.group(1))
+            if level == 1 and skip_first_h1 and not seen_h1:
+                seen_h1 = True
+                i += 1
+                continue
+            out.append(f"<h{level}>{render_inline(m.group(2), resolve)}</h{level}>")
+            i += 1
+            continue
+
+        if stripped.startswith("- "):
+            items: list[str] = []
+            while i < len(lines):
+                cur = lines[i].strip()
+                if cur.startswith("- "):
+                    items.append(cur[2:])
+                elif cur and lines[i].startswith("  ") and items:
+                    items[-1] += " " + cur  # wrapped continuation line
+                else:
+                    break
+                i += 1
+            lis = "".join(f"<li>{render_inline(it, resolve)}</li>" for it in items)
+            out.append(f"<ul>{lis}</ul>")
+            continue
+
+        para: list[str] = [stripped]
+        i += 1
+        while i < len(lines):
+            nxt = lines[i].strip()
+            if not nxt or nxt.startswith(("#", "- ", "```")):
+                break
+            para.append(nxt)
+            i += 1
+        out.append(f"<p>{render_inline(' '.join(para), resolve)}</p>")
+
+    return "\n".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Page assembly
+# ---------------------------------------------------------------------------
 
 def page_relative(repo_rel: str) -> str:
-    """docs/gallery/assets/x.webp -> assets/x.webp (relative to the gallery page)."""
+    """docs/gallery/assets/x.webp -> assets/x.webp (relative to the gallery root)."""
     prefix = "docs/gallery/"
     return repo_rel[len(prefix):] if repo_rel.startswith(prefix) else repo_rel
+
+
+def find_script(ex_dir: Path) -> Path | None:
+    scripts = sorted(p for p in ex_dir.glob("*.py") if p.is_file())
+    return scripts[0] if scripts else None
+
+
+def make_resolver(repo_base: str, ex_dir: str):
+    """Resolve README-relative links against the example dir on GitHub."""
+    def resolve(url: str) -> str:
+        if re.match(r"^[a-z]+://", url) or url.startswith("#"):
+            return url
+        return f"{repo_base}/{posixpath.normpath(posixpath.join(ex_dir, url))}"
+    return resolve
+
+
+def shell(*, title: str, desc: str, canonical: str, og_image: str,
+          site_root: str, back_href: str, back_label: str, repo_url: str,
+          content: str, page_js: str) -> str:
+    return (SHELL
+            .replace("__TITLE__", html.escape(title))
+            .replace("__DESC__", html.escape(desc, quote=True))
+            .replace("__CANONICAL__", html.escape(canonical, quote=True))
+            .replace("__OGIMAGE__", html.escape(og_image, quote=True))
+            .replace("__SITEROOT__", site_root)
+            .replace("__BACKHREF__", back_href)
+            .replace("__BACKLABEL__", html.escape(back_label))
+            .replace("__REPO__", html.escape(repo_url, quote=True))
+            .replace("__CONTENT__", content)
+            .replace("__PAGEJS__", page_js))
+
+
+def build_detail(ex: dict, *, base: str, repo_root_url: str, site: str) -> str:
+    name = ex["name"]
+    ex_dir = REPO / ex["dir"]
+    script = find_script(ex_dir)
+    hero_file = page_relative(ex["hero"]).split("/")[-1]
+
+    parts: list[str] = []
+    parts.append('  <header class="hero">')
+    parts.append(f'    <h1>{html.escape(name)}</h1>')
+    parts.append(f'    <p>{html.escape(ex["teaches"])}</p>')
+    parts.append("  </header>")
+    parts.append('  <main id="main">')
+    parts.append(f'    <button class="detail-hero" id="heroZoom" type="button" aria-label="Zoom {html.escape(name)} render">')
+    parts.append(f'      <img src="../assets/{html.escape(hero_file)}" alt="{html.escape(name)} render" width="1280" height="720" />')
+    parts.append("    </button>")
+    parts.append('    <p class="zoom-hint">Rendered headless by the example itself — click to zoom.</p>')
+    parts.append(f'    <div class="callout"><span class="tag">witnesses</span> {html.escape(ex["witnessesFix"])}</div>')
+
+    if script is not None:
+        cmd = f"blender --background --python {ex['dir']}/{script.name} --"
+        parts.append('    <div class="runline">')
+        parts.append(f'      <pre id="runCmd">{html.escape(cmd)}</pre>')
+        parts.append('      <button class="copy-btn" id="copyRun" type="button">Copy</button>')
+        parts.append("    </div>")
+
+    readme = ex_dir / "README.md"
+    if readme.is_file():
+        resolve = make_resolver(base, ex["dir"])
+        parts.append('    <section class="detail-section md">')
+        parts.append(md_to_html(readme.read_text(encoding="utf-8"), resolve))
+        parts.append("    </section>")
+
+    if script is not None:
+        blob = f"{base}/{ex['dir']}/{script.name}"
+        parts.append('    <section class="detail-section src">')
+        parts.append("      <h2>Source</h2>")
+        parts.append('      <div class="src-meta">')
+        parts.append(f"        <code>{html.escape(ex['dir'])}/{html.escape(script.name)}</code>")
+        parts.append(f'        <a href="{html.escape(blob, quote=True)}">View on GitHub &rarr;</a>')
+        parts.append("      </div>")
+        parts.append(f"      <pre>{highlight_python(script.read_text(encoding='utf-8'))}</pre>")
+        parts.append("    </section>")
+
+    parts.append("  </main>")
+    parts.append('  <div class="lightbox" id="lightbox" role="dialog" aria-label="Full-size render">')
+    parts.append(f'    <img src="../assets/{html.escape(hero_file)}" alt="{html.escape(name)} render, full size" />')
+    parts.append("  </div>")
+
+    return shell(
+        title=f"{name} — Examples — Blender Developer Tools",
+        desc=ex["teaches"],
+        canonical=f"{site}/gallery/{name}/" if site else "",
+        og_image=f"{site}/gallery/assets/{hero_file}" if site else "",
+        site_root="../../",
+        back_href="../",
+        back_label="Examples Gallery",
+        repo_url=repo_root_url,
+        content="\n".join(parts),
+        page_js=DETAIL_JS,
+    )
+
+
+def build_index(data: dict, *, base: str, repo_root_url: str, site: str) -> str:
+    examples = data["examples"]
+    title = data.get("title", "Examples Gallery")
+    desc = data.get("description", "")
+
+    all_tags = sorted({t for ex in examples for t in ex.get("tags", [])})
+    chip_html = ""
+    if all_tags:
+        chips = ['<button class="chip active" data-tag="" type="button">All</button>']
+        chips += [
+            f'<button class="chip" data-tag="{html.escape(t, quote=True)}" type="button">{html.escape(t)}</button>'
+            for t in all_tags
+        ]
+        chip_html = ('  <div class="chips" role="toolbar" aria-label="Filter examples by topic">\n    '
+                     + "\n    ".join(chips) + "\n  </div>\n")
+
+    cards = []
+    for ex in examples:
+        alt = f'{ex["name"]} — {ex["teaches"].split(".")[0]}'
+        cards.append(
+            CARD
+            .replace("__TAGS__", html.escape(" ".join(ex.get("tags", [])), quote=True))
+            .replace("__HREF__", html.escape(f'{ex["name"]}/', quote=True))
+            .replace("__HERO__", html.escape(page_relative(ex["hero"]), quote=True))
+            .replace("__ALT__", html.escape(alt, quote=True))
+            .replace("__NAME__", html.escape(ex["name"]))
+            .replace("__TEACHES__", html.escape(ex["teaches"]))
+            .replace("__WITNESSES__", html.escape(ex["witnessesFix"]))
+        )
+
+    content = (
+        '  <header class="hero">\n'
+        f"    <h1>{html.escape(title)}</h1>\n"
+        f"    <p>{html.escape(desc)}</p>\n"
+        "  </header>\n"
+        + chip_html
+        + '  <main id="main">\n    <div class="grid">\n'
+        + "\n".join(cards)
+        + "\n    </div>\n  </main>"
+    )
+
+    og_image = f"{site}/gallery/assets/{page_relative(examples[0]['hero']).split('/')[-1]}" if site else ""
+    return shell(
+        title=f"{title} — Blender Developer Tools",
+        desc=desc,
+        canonical=f"{site}/gallery/" if site else "",
+        og_image=og_image,
+        site_root="../",
+        back_href="../",
+        back_label="Blender Developer Tools",
+        repo_url=repo_root_url,
+        content=content,
+        page_js=INDEX_JS,
+    )
 
 
 def main() -> int:
@@ -197,41 +595,33 @@ def main() -> int:
     base = data["repoBaseUrl"].rstrip("/")
     repo_root_url = base.split("/tree/")[0]  # strip /tree/<ref> -> repo home
     site = data.get("siteBaseUrl", "").rstrip("/")
-    title = data.get("title", "Examples Gallery")
-    desc = data.get("description", "")
     examples = data["examples"]
     if not examples:
         print("ERROR: no examples in gallery.json", file=sys.stderr)
         return 2
 
-    cards = []
     for ex in examples:
         if not (REPO / ex["hero"]).is_file():
             print(f"ERROR: hero image missing: {ex['hero']}", file=sys.stderr)
             return 3
-        alt = f'{ex["name"]} — {ex["teaches"].split(".")[0]}'
-        card = (CARD
-                .replace("__HREF__", html.escape(f"{base}/{ex['dir']}"))
-                .replace("__HERO__", html.escape(page_relative(ex["hero"])))
-                .replace("__ALT__", html.escape(alt))
-                .replace("__NAME__", html.escape(ex["name"]))
-                .replace("__TEACHES__", html.escape(ex["teaches"]))
-                .replace("__WITNESSES__", html.escape(ex["witnessesFix"])))
-        cards.append(card)
+        if find_script(REPO / ex["dir"]) is None:
+            print(f"ERROR: no .py script in {ex['dir']}", file=sys.stderr)
+            return 4
 
-    og_image = f"{site}/gallery/assets/{page_relative(examples[0]['hero']).split('/')[-1]}" if site else ""
-    canonical = f"{site}/gallery/" if site else ""
-    out_html = (PAGE
-                .replace("__CARDS__", "\n".join(cards))
-                .replace("__TITLE__", html.escape(title))
-                .replace("__DESC__", html.escape(desc))
-                .replace("__CANONICAL__", html.escape(canonical))
-                .replace("__OGIMAGE__", html.escape(og_image))
-                .replace("__REPO__", html.escape(repo_root_url)))
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    (OUT_DIR / "index.html").write_text(
+        build_index(data, base=base, repo_root_url=repo_root_url, site=site),
+        encoding="utf-8",
+    )
+    for ex in examples:
+        page_dir = OUT_DIR / ex["name"]
+        page_dir.mkdir(parents=True, exist_ok=True)
+        (page_dir / "index.html").write_text(
+            build_detail(ex, base=base, repo_root_url=repo_root_url, site=site),
+            encoding="utf-8",
+        )
 
-    OUT.parent.mkdir(parents=True, exist_ok=True)
-    OUT.write_text(out_html, encoding="utf-8")
-    print(f"Wrote {OUT} ({len(examples)} examples)")
+    print(f"Wrote {OUT_DIR / 'index.html'} + {len(examples)} detail pages")
     return 0
 
 


### PR DESCRIPTION
## Summary
Phase 3 of the site upgrade — the gallery becomes a destination instead of a link farm.

- **Detail pages** at `gallery/<name>/` per example: hero with click-to-zoom lightbox (ESC closes), witnesses callout, copyable canonical run command, README rendered inline (headings, lists, bold, inline code, fenced blocks; relative links resolve to GitHub), and the full Python source **syntax-highlighted at build time** with stdlib `tokenize` — no Pygments, no Jinja; the stdlib-only rule holds.
- **Filter chips** on the gallery index from an additive `tags` field in `gallery.json` (schema change is additive-only per its `_comment` contract).
- **Cards link to detail pages**; GitHub links live on the detail page.
- **Per-page SEO**: unique title/description/canonical/og:image per example.
- `pages.yml` now triggers on `examples/**` so embedded source/READMEs rebuild on change.

## Testing
Built locally and drove it in a browser: all 4 detail pages render (README markdown clean, no stray markup outside code blocks), lightbox opens and ESC-closes, chips filter correctly (`animation` → turntable only, All resets to 4), cards navigate to detail pages, theme toggle carries across pages via the shared localStorage key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)