### PR TITLE
docs: favicon joins the viewport design system

### DIFF
--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,10 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Blender Developer Tools">
-  <defs>
-    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#a78bfa"/>
-      <stop offset="1" stop-color="#7c3aed"/>
-    </linearGradient>
-  </defs>
-  <rect width="64" height="64" rx="14" fill="url(#g)"/>
-  <path d="M20 44V20h12.5c5 0 8 2.4 8 6.4 0 2.6-1.4 4.5-3.7 5.3 2.9.6 4.8 2.8 4.8 5.9 0 4.2-3.2 6.4-8.6 6.4H20zm6.4-14.4h5c2 0 3.1-.9 3.1-2.4S33.4 24.8 31.4 24.8h-5v4.8zm0 9.6h5.4c2.1 0 3.3-1 3.3-2.6s-1.2-2.6-3.3-2.6h-5.4v5.2z" fill="#fff"/>
+  <rect width="64" height="64" rx="14" fill="#1a1b1e"/>
+  <rect width="64" height="64" rx="14" fill="none" stroke="#3a3b40" stroke-width="2"/>
+  <path d="M20 44V20h12.5c5 0 8 2.4 8 6.4 0 2.6-1.4 4.5-3.7 5.3 2.9.6 4.8 2.8 4.8 5.9 0 4.2-3.2 6.4-8.6 6.4H20zm6.4-14.4h5c2 0 3.1-.9 3.1-2.4S33.4 24.8 31.4 24.8h-5v4.8zm0 9.6h5.4c2.1 0 3.3-1 3.3-2.6s-1.2-2.6-3.3-2.6h-5.4v5.2z" fill="#ff8c19"/>
 </svg>


### PR DESCRIPTION
Replaces the old purple-gradient favicon with the viewport system: Blender panel dark (`#1a1b1e`) with a `#3a3b40` border and the selection-orange (`#ff8c19`) B monogram. Same B path, recolored — recognizable at 16px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)