### PR TITLE
ci: enforce the README example count in validate-counts

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -244,6 +244,11 @@ jobs:
               f for f in os.listdir('snippets')
               if f.endswith('.py')
           ])
+          example_count = len([
+              d for d in os.listdir('examples')
+              if os.path.isdir(os.path.join('examples', d))
+              and os.path.exists(os.path.join('examples', d, 'README.md'))
+          ])
 
           readme = open('README.md').read()
           if f'{skill_count} skills' not in readme:
@@ -255,11 +260,13 @@ jobs:
               errors.append(f'README template count mismatch (expected "{template_count} {template_word}" substring)')
           if f'{snippet_count} snippets' not in readme:
               errors.append(f'README snippet count mismatch (expected "{snippet_count} snippets" substring)')
+          if f'{example_count} examples' not in readme:
+              errors.append(f'README example count mismatch (expected "{example_count} examples" substring)')
 
           if errors:
               for e in errors:
                   print(f'::error::{e}', file=sys.stderr)
               sys.exit(1)
 
-          print(f'Counts verified: {skill_count} skills, {rule_count} rules, {template_count} {template_word}, {snippet_count} snippets')
+          print(f'Counts verified: {skill_count} skills, {rule_count} rules, {template_count} {template_word}, {snippet_count} snippets, {example_count} examples')
           PYEOF

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,9 +119,9 @@ way, and a one-paragraph rationale. 30 to 80 lines is the right size.
 ## CI/CD workflows
 
 - `validate.yml` runs file structure checks plus a `validate-counts` job that
-  asserts the README aggregate counts (12 skills, 6 rules, 2 templates, 17
-  snippets) match filesystem reality. The counts language in `README.md` is
-  load-bearing: the job greps for it.
+  asserts the README aggregate counts (skills, rules, templates, snippets,
+  and examples) match filesystem reality. The counts language in `README.md`
+  is load-bearing: the job greps for it.
 - `validate.yml` also runs a `validate-manifest` job that checks
   `.cursor-plugin/plugin.json` against reality: every listed path must exist,
   every skill, rule, snippet, template, and example on disk must be listed,


### PR DESCRIPTION
The `validate-counts` job enforced the skills/rules/templates/snippets counts in README.md but not the examples count, so the "20 examples" figure could silently go stale when example #21 lands (flagged in the README QoL pass, #63).

- Counts `examples/<dir>/` directories that contain a `README.md` (robust against stray non-example dirs), mirroring how skills are counted by `SKILL.md` presence.
- Adds the same substring check the other counts use: `"{n} examples"` must appear in README.md.
- AGENTS.md's description of the job updated to the durable form (names the five content types instead of hard-coding numbers).

**Proven to fail**: the check logic was run locally against the real README (pass, 20 counted) and against a README with "20 examples" edited to "19 examples" (fails with the expected error message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)