### PR TITLE
fix: gallery alts truncate on dotted API paths + version example prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,6 @@ ehthumbs.db
 
 # Local planning docs (not published)
 docs/site-upgrade-plan.md
-docs/new-example-prompt.md
-
 # Landing-page build outputs (generated at deploy time by scripts/site/build_site.py;
 # docs/gallery/ stays committed)
 docs/index.html

--- a/docs/gallery/index.html
+++ b/docs/gallery/index.html
@@ -205,7 +205,7 @@
     <div class="grid">
       <article class="card" data-tags="materials rendering">
         <a class="card-media" href="swatch-grid/" aria-label="swatch-grid example detail page">
-          <img src="assets/swatch-grid-hero.webp" alt="swatch-grid — Procedural Principled materials — metal and dielectric, the emission pattern, and the cross-version set_specular shim" loading="lazy" decoding="async" />
+          <img src="assets/swatch-grid-hero.webp" alt="swatch-grid — Procedural Principled materials — metal and dielectric, the emission pattern, and the cross-version set_specular shim." loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="swatch-grid/">swatch-grid</a></h2>
@@ -216,7 +216,7 @@
       </article>
       <article class="card" data-tags="animation">
         <a class="card-media" href="turntable/" aria-label="turntable example detail page">
-          <img src="assets/turntable-hero.webp" alt="turntable — A slotted-actions Z-rotation turntable keyed through the cross-version channelbag path (get_channelbag_for_slot)" loading="lazy" decoding="async" />
+          <img src="assets/turntable-hero.webp" alt="turntable — A slotted-actions Z-rotation turntable keyed through the cross-version channelbag path (get_channelbag_for_slot)." loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="turntable/">turntable</a></h2>
@@ -227,7 +227,7 @@
       </article>
       <article class="card" data-tags="geometry-nodes materials">
         <a class="card-media" href="gn-sdf-remesh/" aria-label="gn-sdf-remesh example detail page">
-          <img src="assets/gn-sdf-remesh-hero.webp" alt="gn-sdf-remesh — A Geometry Nodes SDF remesh (MeshToSDFGrid → GridToMesh at the SDF zero-level), with a Set Material node carrying the material through the remesh" loading="lazy" decoding="async" />
+          <img src="assets/gn-sdf-remesh-hero.webp" alt="gn-sdf-remesh — A Geometry Nodes SDF remesh (MeshToSDFGrid → GridToMesh at the SDF zero-level), with a Set Material node carrying the material through the remesh." loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="gn-sdf-remesh/">gn-sdf-remesh</a></h2>
@@ -238,7 +238,7 @@
       </article>
       <article class="card" data-tags="depsgraph export">
         <a class="card-media" href="depsgraph-export/" aria-label="depsgraph-export example detail page">
-          <img src="assets/depsgraph-export-hero.webp" alt="depsgraph-export — The depsgraph lifetime contract — evaluated_get()" loading="lazy" decoding="async" />
+          <img src="assets/depsgraph-export-hero.webp" alt="depsgraph-export — The depsgraph lifetime contract — evaluated_get().to_mesh() paired with to_mesh_clear() — measured against an OBJ export of the same object." loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="depsgraph-export/">depsgraph-export</a></h2>
@@ -249,7 +249,7 @@
       </article>
       <article class="card" data-tags="mesh performance">
         <a class="card-media" href="wave-displace/" aria-label="wave-displace example detail page">
-          <img src="assets/wave-displace-hero.webp" alt="wave-displace — Bulk vertex IO at real scale — 9,409 vertices displaced into a standing wave with one foreach_get and one foreach_set, no per-vertex access" loading="lazy" decoding="async" />
+          <img src="assets/wave-displace-hero.webp" alt="wave-displace — Bulk vertex IO at real scale — 9,409 vertices displaced into a standing wave with one foreach_get and one foreach_set, no per-vertex access." loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="wave-displace/">wave-displace</a></h2>
@@ -260,7 +260,7 @@
       </article>
       <article class="card" data-tags="drivers animation">
         <a class="card-media" href="driver-wave/" aria-label="driver-wave example detail page">
-          <img src="assets/driver-wave-hero.webp" alt="driver-wave — A driver_namespace function driving sixteen column heights through SCRIPTED drivers — the sine skyline is entirely driver-evaluated" loading="lazy" decoding="async" />
+          <img src="assets/driver-wave-hero.webp" alt="driver-wave — A driver_namespace function driving sixteen column heights through SCRIPTED drivers — the sine skyline is entirely driver-evaluated." loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="driver-wave/">driver-wave</a></h2>
@@ -271,7 +271,7 @@
       </article>
       <article class="card" data-tags="mesh bmesh">
         <a class="card-media" href="bmesh-gear/" aria-label="bmesh-gear example detail page">
-          <img src="assets/bmesh-gear-hero.webp" alt="bmesh-gear — A 14-tooth gear built entirely with bmesh — profile ring, face, extrude — with bm" loading="lazy" decoding="async" />
+          <img src="assets/bmesh-gear-hero.webp" alt="bmesh-gear — A 14-tooth gear built entirely with bmesh — profile ring, face, extrude — with bm.free() in a try/finally, exactly as the ownership contract demands." loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="bmesh-gear/">bmesh-gear</a></h2>
@@ -282,7 +282,7 @@
       </article>
       <article class="card" data-tags="materials node-groups">
         <a class="card-media" href="shader-node-group/" aria-label="shader-node-group example detail page">
-          <img src="assets/shader-node-group-hero.webp" alt="shader-node-group — One reusable shader group declared via tree" loading="lazy" decoding="async" />
+          <img src="assets/shader-node-group-hero.webp" alt="shader-node-group — One reusable shader group declared via tree.interface.new_socket, instanced in two materials with different Tint values — two spheres, one group, two colors." loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="shader-node-group/">shader-node-group</a></h2>
@@ -293,7 +293,7 @@
       </article>
       <article class="card" data-tags="operators context">
         <a class="card-media" href="temp-override-join/" aria-label="temp-override-join example detail page">
-          <img src="assets/temp-override-join-hero.webp" alt="temp-override-join — Join three unit cubes into a staircase under bpy" loading="lazy" decoding="async" />
+          <img src="assets/temp-override-join-hero.webp" alt="temp-override-join — Join three unit cubes into a staircase under bpy.context.temp_override — the supported replacement for the removed context.copy() dict-pass form." loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="temp-override-join/">temp-override-join</a></h2>
@@ -304,7 +304,7 @@
       </article>
       <article class="card" data-tags="geometry-nodes instancing">
         <a class="card-media" href="gn-instance-grid/" aria-label="gn-instance-grid example detail page">
-          <img src="assets/gn-instance-grid-hero.webp" alt="gn-instance-grid — A generative Geometry Nodes tree — Mesh Grid → Instance on Points → Realize Instances → Set Shade Smooth — attached as a NODES modifier with no Group Input geometry" loading="lazy" decoding="async" />
+          <img src="assets/gn-instance-grid-hero.webp" alt="gn-instance-grid — A generative Geometry Nodes tree — Mesh Grid → Instance on Points → Realize Instances → Set Shade Smooth — attached as a NODES modifier with no Group Input…" loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="gn-instance-grid/">gn-instance-grid</a></h2>
@@ -315,7 +315,7 @@
       </article>
       <article class="card" data-tags="mesh shape-keys">
         <a class="card-media" href="shape-key-blend/" aria-label="shape-key-blend example detail page">
-          <img src="assets/shape-key-blend-hero.webp" alt="shape-key-blend — A relative Tall shape key that lifts and flares the top face — authored via shape_key_add / key_blocks / " loading="lazy" decoding="async" />
+          <img src="assets/shape-key-blend-hero.webp" alt="shape-key-blend — A relative Tall shape key that lifts and flares the top face — authored via shape_key_add / key_blocks / .value — read back from the depsgraph-evaluated mesh." loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="shape-key-blend/">shape-key-blend</a></h2>
@@ -326,7 +326,7 @@
       </article>
       <article class="card" data-tags="curves bevel">
         <a class="card-media" href="curve-bevel-arc/" aria-label="curve-bevel-arc example detail page">
-          <img src="assets/curve-bevel-arc-hero.webp" alt="curve-bevel-arc — A beveled Bezier semicircle authored on bpy" loading="lazy" decoding="async" />
+          <img src="assets/curve-bevel-arc-hero.webp" alt="curve-bevel-arc — A beveled Bezier semicircle authored on bpy.types.Curve — splines.new(&#x27;BEZIER&#x27;), bezier_points, bevel_depth, use_fill_caps — so the curve renders as a solid…" loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="curve-bevel-arc/">curve-bevel-arc</a></h2>
@@ -337,7 +337,7 @@
       </article>
       <article class="card" data-tags="compositor rendering">
         <a class="card-media" href="compositor-glare/" aria-label="compositor-glare example detail page">
-          <img src="assets/compositor-glare-hero.webp" alt="compositor-glare — Bloom where it actually lives — a compositor Glare (Fog Glow) node fed by Render Layers, wired via scene" loading="lazy" decoding="async" />
+          <img src="assets/compositor-glare-hero.webp" alt="compositor-glare — Bloom where it actually lives — a compositor Glare (Fog Glow) node fed by Render Layers, wired via scene.compositing_node_group on 5.x and scene.node_tree on…" loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="compositor-glare/">compositor-glare</a></h2>
@@ -348,7 +348,7 @@
       </article>
       <article class="card" data-tags="constraints animation">
         <a class="card-media" href="damped-track-aim/" aria-label="damped-track-aim example detail page">
-          <img src="assets/damped-track-aim-hero.webp" alt="damped-track-aim — Aim constraints via the data API — Object" loading="lazy" decoding="async" />
+          <img src="assets/damped-track-aim-hero.webp" alt="damped-track-aim — Aim constraints via the data API — Object.constraints.new(&#x27;DAMPED_TRACK&#x27;) with target and TRACK_Z, not bpy.ops.object.constraint_add in a headless loop." loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="damped-track-aim/">damped-track-aim</a></h2>
@@ -359,7 +359,7 @@
       </article>
       <article class="card" data-tags="mesh materials attributes">
         <a class="card-media" href="color-attribute-wheel/" aria-label="color-attribute-wheel example detail page">
-          <img src="assets/color-attribute-wheel-hero.webp" alt="color-attribute-wheel — The modern color-attributes API — mesh" loading="lazy" decoding="async" />
+          <img src="assets/color-attribute-wheel-hero.webp" alt="color-attribute-wheel — The modern color-attributes API — mesh.color_attributes.new() on the CORNER domain, filled by expanding per-vertex HSV across face corners with…" loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="color-attribute-wheel/">color-attribute-wheel</a></h2>
@@ -370,7 +370,7 @@
       </article>
       <article class="card" data-tags="objects transforms">
         <a class="card-media" href="parent-inverse-orrery/" aria-label="parent-inverse-orrery example detail page">
-          <img src="assets/parent-inverse-orrery-hero.webp" alt="parent-inverse-orrery — Data-API parenting for a brass orrery — the keep-world idiom (child" loading="lazy" decoding="async" />
+          <img src="assets/parent-inverse-orrery-hero.webp" alt="parent-inverse-orrery — Data-API parenting for a brass orrery — the keep-world idiom (child.parent = pivot; child.matrix_parent_inverse = pivot.matrix_world.inverted()) carrying arms…" loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="parent-inverse-orrery/">parent-inverse-orrery</a></h2>
@@ -381,7 +381,7 @@
       </article>
       <article class="card" data-tags="grease-pencil attributes">
         <a class="card-media" href="grease-pencil-rosette/" aria-label="grease-pencil-rosette example detail page">
-          <img src="assets/grease-pencil-rosette-hero.webp" alt="grease-pencil-rosette — Grease Pencil v3&#x27;s attribute-based API — layer → frames" loading="lazy" decoding="async" />
+          <img src="assets/grease-pencil-rosette-hero.webp" alt="grease-pencil-rosette — Grease Pencil v3&#x27;s attribute-based API — layer → frames.new(1).drawing → add_strokes → per-point position/radius/opacity/vertex_color — drawing five nested…" loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="grease-pencil-rosette/">grease-pencil-rosette</a></h2>
@@ -392,7 +392,7 @@
       </article>
       <article class="card" data-tags="armature depsgraph">
         <a class="card-media" href="armature-bend/" aria-label="armature-bend example detail page">
-          <img src="assets/armature-bend-hero.webp" alt="armature-bend — Rigging end to end in the data API — edit_bones chain construction, name-bound vertex groups with smoothstep blend zones, posing, and depsgraph evaluation — bending a tapered tube through rest, half, and full curl" loading="lazy" decoding="async" />
+          <img src="assets/armature-bend-hero.webp" alt="armature-bend — Rigging end to end in the data API — edit_bones chain construction, name-bound vertex groups with smoothstep blend zones, posing, and depsgraph evaluation…" loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="armature-bend/">armature-bend</a></h2>
@@ -403,7 +403,7 @@
       </article>
       <article class="card" data-tags="curves depsgraph rendering">
         <a class="card-media" href="text-version-stamp/" aria-label="text-version-stamp example detail page">
-          <img src="assets/text-version-stamp-hero.webp" alt="text-version-stamp — The TextCurve data API — curves" loading="lazy" decoding="async" />
+          <img src="assets/text-version-stamp-hero.webp" alt="text-version-stamp — The TextCurve data API — curves.new(type=&#x27;FONT&#x27;), live body text from bpy.app.version_string, extrude and bevel_depth solids, and evaluated-mesh conversion…" loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="text-version-stamp/">text-version-stamp</a></h2>
@@ -414,7 +414,7 @@
       </article>
       <article class="card" data-tags="images performance rendering">
         <a class="card-media" href="image-pixels-testcard/" aria-label="image-pixels-testcard example detail page">
-          <img src="assets/image-pixels-testcard-hero.webp" alt="image-pixels-testcard — The Image pixel-buffer contract — a procedural broadcast test card written into bpy" loading="lazy" decoding="async" />
+          <img src="assets/image-pixels-testcard-hero.webp" alt="image-pixels-testcard — The Image pixel-buffer contract — a procedural broadcast test card written into bpy.data.images.new() with one pixels.foreach_set (589,824 floats), byte vs…" loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="image-pixels-testcard/">image-pixels-testcard</a></h2>
@@ -425,7 +425,7 @@
       </article>
       <article class="card" data-tags="mesh bmesh uv materials">
         <a class="card-media" href="uv-layer-grid/" aria-label="uv-layer-grid example detail page">
-          <img src="assets/uv-layer-grid-hero.webp" alt="uv-layer-grid — The UV-layer authoring hazard — bmesh" loading="lazy" decoding="async" />
+          <img src="assets/uv-layer-grid-hero.webp" alt="uv-layer-grid — The UV-layer authoring hazard — bmesh.ops.create_grid(..., calc_uvs=True) is a silent no-op unless a UV layer already exists; without one an Image Texture…" loading="lazy" decoding="async" />
         </a>
         <div class="card-body">
           <h2><a href="uv-layer-grid/">uv-layer-grid</a></h2>

--- a/docs/new-example-prompt.md
+++ b/docs/new-example-prompt.md
@@ -1,0 +1,131 @@
+# Prompt: Create a new Blender example
+
+Copy everything below this line into the agent.
+
+---
+
+Create, ship, and merge one original, runnable example for this repository. The bar is
+not "a working example"; it is an example strong enough to anchor the gallery on its own.
+
+First, review `CLAUDE.md`, `AGENTS.md`, `ROADMAP.md`, `examples/gallery.json`,
+`docs/VISUAL-STYLE.md`, and several existing examples—study the strongest ones, not
+just the nearest one. Use them to understand the repository's current conventions,
+integration points, visual standard, and test structure. Check all existing examples
+before choosing a subject so your contribution does not duplicate or slightly
+repackage something already covered.
+
+Before editing, inspect the Git state. Start from an up-to-date `main`, preserve unrelated
+work, and create a focused feature branch. Never force-push or bypass hooks. Do not include
+secrets, temporary renders, caches, or unrelated files.
+
+Subject selection. Prefer the ROADMAP candidate pool if it has entries; otherwise choose
+freely. Whatever the source, the subject must pass all of these tests before you write
+code:
+
+- It witnesses a real, load-bearing API contract—something with observable behavior
+  that can drift, not a convenience wrapper or a tutorial topic. The strongest subjects
+  are ones AI-generated Blender code commonly gets wrong: object-mode versus edit-mode
+  data lifetimes, evaluated versus original data, ordering constraints, references that
+  dangle after CustomData reallocation, APIs renamed or restructured between 4.5 LTS
+  and 5.1.
+- Its check can fail for a real reason. Before trusting any assertion, prove it catches
+  the failure it claims to catch: temporarily break the contract (skip the pose, swap
+  the buffer, use the legacy path) and confirm the check exits non-zero, then restore
+  it. An assertion that cannot fail witnesses nothing. State in the README what failure
+  each check would catch.
+- Its correctness is independently derivable. The best checks compare Blender's output
+  against a closed-form or independently computed expectation (re-implemented math, a
+  round-trip through a raw buffer, a known geometric invariant), not against a value
+  captured from a previous run of the same code.
+- Its render is legible as proof. Someone glancing at the thumbnail should be able to
+  infer what contract is being demonstrated. If the render would look the same whether
+  the API worked or not, redesign the scene until failure would be visible.
+
+Where an API diverges between 4.5 and 5.1, asserting each side's actual contract is part
+of the witness—version-gate explicitly and document the divergence rather than papering
+over it. If you discover an undocumented hazard while authoring (a crash, a dangling
+reference, an ordering constraint), that discovery belongs in the code comments and
+README; it is often more valuable than the original subject.
+
+The example must:
+
+- run headlessly in Blender 5.1 and Blender 4.5 LTS;
+- perform deterministic checks of a real Blender API contract and exit non-zero on
+  failure, with numeric tolerances chosen deliberately and printed on success so CI
+  logs carry the measured values;
+- default to a fast check-only run and optionally render its own gallery image;
+- follow repository conventions and relevant Blender safety rules;
+- include concise documentation explaining what it teaches, what each check witnesses,
+  what failure it would catch, and any version-gated divergence between 4.5 and 5.1;
+- produce a deliberate, well-framed render rather than a mockup, primitive dump, or
+  placeholder.
+
+Complete every integration required for a shipped example. Infer the exact current
+shape from neighboring examples and repository configuration, including the example
+directory, README, gallery metadata and assets, plugin manifest, smoke workflow,
+top-level README, and generated gallery pages. After regenerating the gallery with
+`python scripts/build_gallery.py`, read the **generated** output character by
+character — not only `examples/gallery.json` source fields. Open
+`docs/gallery/index.html` and `docs/gallery/<name>/index.html` and inspect the
+rendered `<img alt>` text and the witnesses callout for duplicated words, truncation,
+and generator artifacts (the previous `teaches.split(".")[0]` bug truncated alts at
+dotted API paths like `bmesh.ops`; source JSON looked fine). Keep the ROADMAP
+candidate pool in sync: remove the shipped subject, and add any promising subjects
+you identified but did not build. Do not hand-edit release-owned version fields or
+generated pages; use the repository's generator.
+
+Run the new example's check-only path on both supported Blender versions, render and
+visually inspect its final image, regenerate the gallery, and run all relevant repository
+validation. If Blender 4.5 is unavailable locally, say so precisely and use the repository's
+4.5 CI job—do not substitute another version and report it as 4.5. If the render path
+requires an engine or device unavailable locally (Cycles on a GPU-less host), say so and
+identify exactly which paths were exercised only in CI or by inspection. Fix every
+failure you introduce.
+
+Treat visual quality as a shipping gate with the same rigor as the checks. Conform to
+`docs/VISUAL-STYLE.md` explicitly (Standard view transform, dark studio stage, AREA
+key/fill/rim/wedge, designed hero materials, framing, 1280×720 → hero/preview webp).
+Inspect the actual rendered pixels at full size and as the gallery thumbnail.
+Iterate—the first render is a draft, not a candidate. Revise until the subject and
+demonstrated API contract are immediately readable, the composition is intentional,
+important geometry is not clipped, highlights are not blown out, lights or helper
+objects are not visible unintentionally, and materials, lighting, background, and
+camera feel designed rather than left at Blender defaults.
+
+Contact-sheet gate (required before shipping the still): place the new hero beside
+the pinned calibration set — currently `armature-bend`, `damped-track-aim`,
+`bmesh-gear` — and compare stage darkness, wedge warmth, subject fill, saturation,
+and thumbnail legibility side by side. Do not ship until the new image holds up in
+that lineup—not merely "looks fine alone." Update this named set in this prompt
+whenever a new example outclasses one of them. One successful render command is not
+proof that the image is good, and neither is the second. Report that the
+contact-sheet comparison was done against those three references.
+
+After implementation and local verification:
+
+1. Review the complete diff and remove accidental churn or temporary files.
+2. Commit the focused change with a conventional, release-worthy `feat:` subject that
+   explains why the example belongs in the repository.
+3. Push the feature branch and open a pull request against `main` with a concise summary,
+   the API contract witnessed, what failure each check catches (and proof you falsified
+   it once), visual notes, and an exact test plan. Label explicitly what was proven by
+   live run versus established by inspection only.
+4. Watch every attached PR check, including validation, manifest/count checks, ecosystem
+   drift, security checks, and Blender 4.5/5.1 smoke jobs. Investigate and fix failures
+   within this change's scope, push fixes, and repeat until all checks pass.
+5. Review PR comments and requested changes. Apply valid feedback and re-run affected
+   checks. Do not merge with unresolved failures or requested changes.
+6. Once the PR is mergeable and green, merge it using the repository's normal merge
+   strategy and delete the remote feature branch.
+7. Wait for any automated release/version-sync commit triggered by the merge, then
+   fast-forward local `main` to `origin/main`, and verify main HEAD is green including
+   all post-merge jobs (release, validate, drift, pages deploy). Do not hand-edit
+   release-owned version fields.
+8. Confirm the final working tree is clean and report the PR URL, merge commit, resulting
+   version (if released), measured check values, and checks completed.
+
+Do not stop at a proposal or ask me to choose the topic. Explore, choose, implement,
+verify, ship, merge, synchronize, and report the completed result. Only stop for a real
+blocker that requires user action, such as authentication, an unavailable required
+runtime with no CI substitute, a merge policy requiring approval, or unrelated local
+changes that cannot be safely preserved.

--- a/scripts/build_gallery.py
+++ b/scripts/build_gallery.py
@@ -34,6 +34,60 @@ REPO = Path(__file__).resolve().parent.parent
 DATA = REPO / "examples" / "gallery.json"
 OUT_DIR = REPO / "docs" / "gallery"
 
+# Soft cap for gallery index card alt text (accessibility + layout).
+_ALT_CAP = 160
+
+
+def first_sentence(text: str) -> str:
+    """First sentence of *text*, splitting on period-followed-by-whitespace.
+
+    Do not use ``str.split(".")[0]``: bpy teaches strings are full of dotted
+    API paths (``bmesh.ops.create_grid``, ``bpy.context.temp_override``), and
+    that split truncates mid-identifier.
+    """
+    m = re.search(r"\.\s+", text)
+    if m:
+        return text[: m.start() + 1].strip()
+    return text.strip()
+
+
+def card_alt(name: str, teaches: str, *, cap: int = _ALT_CAP) -> str:
+    """Gallery card ``<img alt>``: ``{name} — {first sentence}``, length-capped."""
+    first = first_sentence(teaches)
+    if len(first) > cap:
+        cut = first[:cap].rsplit(" ", 1)[0].rstrip(".,;: —-")
+        first = (cut if cut else first[:cap].rstrip()) + "…"
+    return f"{name} — {first}"
+
+
+def assert_alts_survive_dotted_paths(examples: list) -> None:
+    """Fail the build if any card alt is still truncated at the first ``.``.
+
+    Catches regressions of the old ``teaches.split(".")[0]`` bug for every
+    example whose first sentence contains a dotted identifier.
+    """
+    for ex in examples:
+        teaches = ex["teaches"]
+        name = ex["name"]
+        alt = card_alt(name, teaches)
+        first_dot = teaches.find(".")
+        if first_dot < 0:
+            continue
+        # First "." is a real sentence end (EOS or whitespace after it).
+        if first_dot == len(teaches) - 1 or teaches[first_dot + 1].isspace():
+            continue
+        suffix = alt.split(" — ", 1)[-1]
+        if len(suffix) <= first_dot:
+            raise SystemExit(
+                f"gallery alt truncated at dotted API path for {name!r}: {alt!r}"
+            )
+        # Old bug would have produced exactly this string:
+        legacy = f"{name} — {teaches.split('.')[0]}"
+        if alt == legacy:
+            raise SystemExit(
+                f"gallery alt still matches legacy split('.')[0] for {name!r}: {alt!r}"
+            )
+
 # ---------------------------------------------------------------------------
 # Shared page shell. __ROOT__ is the relative prefix from the page to the
 # gallery root ("" for the index, "../" for detail pages); __SITEROOT__ is the
@@ -534,7 +588,7 @@ def build_index(data: dict, *, base: str, repo_root_url: str, site: str) -> str:
 
     cards = []
     for ex in examples:
-        alt = f'{ex["name"]} — {ex["teaches"].split(".")[0]}'
+        alt = card_alt(ex["name"], ex["teaches"])
         cards.append(
             CARD
             .replace("__TAGS__", html.escape(" ".join(ex.get("tags", [])), quote=True))
@@ -589,6 +643,8 @@ def main() -> int:
         if find_script(REPO / ex["dir"]) is None:
             print(f"ERROR: no .py script in {ex['dir']}", file=sys.stderr)
             return 4
+
+    assert_alts_survive_dotted_paths(examples)
 
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     (OUT_DIR / "index.html").write_text(


### PR DESCRIPTION
## Summary
- **fix:** Gallery index card `alt` no longer uses `teaches.split('.')[0]`, which truncated 14/21 cards mid-identifier (`bmesh.ops`, `bpy.context`, …). Sentence split is period-followed-by-whitespace with a 160-char cap; `assert_alts_survive_dotted_paths` fails the build if the legacy form returns.
- Regenerated `docs/gallery/index.html` — verified all 14 previously truncated alts are full in the HTML (incl. `uv-layer-grid` → `bmesh.ops.create_grid`).
- **docs:** Track `docs/new-example-prompt.md` (removed from `.gitignore`); pin contact-sheet calibration set to `armature-bend`, `damped-track-aim`, `bmesh-gear`; require reading **generated** HTML alt/callout after regen, not only JSON source.

## Test plan
- [x] `python scripts/build_gallery.py` exits 0
- [x] All 14 dotted-path alts longer than first `.` and not equal to legacy split
- [x] Assert probe: monkeypatched legacy `card_alt` → SystemExit
- [ ] CI validate / drift

Made with [Cursor](https://cursor.com)