### PR TITLE
fix: sync vertex-weight-limit README numbers to the remodeled check output

### DIFF
--- a/docs/gallery/vertex-weight-limit/index.html
+++ b/docs/gallery/vertex-weight-limit/index.html
@@ -186,7 +186,7 @@
 <p>A runnable example that rigs a mech arm — flanged bolted pedestal and shoulder fairing, a panel-seamed upper arm ending in clevis cheeks, the elbow hinge pin and knuckle barrel capped with hex bolts through a ribbed flex cuff, a long seam-grooved forearm, wrist cuff and collar, and a three-finger gripper — with deliberately rich five-bone weight bumps in the cuffs, then enforces the game-engine <strong>maximum of four bone influences per vertex</strong> through the data API, following <a href="https://github.com/TMHSDigital/Blender-Developer-Tools/tree/main/skills/mesh-editing-and-bmesh/SKILL.md"><code>mesh-editing-and-bmesh</code></a> and building on the linear-blend-skinning precedent of <a href="https://github.com/TMHSDigital/Blender-Developer-Tools/tree/main/examples/armature-bend"><code>armature-bend</code></a>.</p>
 <p><strong>Pipeline arc:</strong> modeling/LOD in <a href="https://github.com/TMHSDigital/Blender-Developer-Tools/tree/main/examples/lod-decimate-chain"><code>lod-decimate-chain</code></a>, weighting here, export in <a href="https://github.com/TMHSDigital/Blender-Developer-Tools/tree/main/examples/gltf-export-roundtrip"><code>gltf-export-roundtrip</code></a>.</p>
 <p><strong>What it witnesses:</strong> the skinning constraint every game engine enforces and AI-generated rigging code most often violates silently.</p>
-<p>1. <strong>The limit is a data-API operation, not a context operator.</strong> Instead of <code>bpy.ops.object.vertex_group_limit_total</code>, the example reads each vertex&#x27;s groups, keeps the top four by weight, <code>VertexGroup.remove</code>s the rest, and renormalizes the survivors. Dropping without renormalizing leaves sums at 0.986 — a mesh that shrinks toward the origin under load (the check&#x27;s measured failure, 1.438e-02 off unit sum). 2. <strong>The armature modifier is still exactly linear blend skinning</strong> after the limit: every depsgraph-evaluated vertex equals <code>Σ wᵢ · (pose.matrix @ bone.matrix_local.inverted()) @ rest</code>, with the weights <strong>read back from the mesh&#x27;s own deform layer</strong> (<code>v.groups</code>) — the weights on the mesh are the contract, not the weights you meant to write. Measured <code>lbs_err = 3.0e-07</code>. 3. <strong>Pruning must not damage the pose.</strong> Evaluated positions before and after the limit are held within 0.05 (measured 3.0e-03), the pedestal mount stays exactly pinned (Root is unposed), and the pre-limit authoring really carries five influences in the boots — otherwise the witness would be vacuous.</p>
+<p>1. <strong>The limit is a data-API operation, not a context operator.</strong> Instead of <code>bpy.ops.object.vertex_group_limit_total</code>, the example reads each vertex&#x27;s groups, keeps the top four by weight, <code>VertexGroup.remove</code>s the rest, and renormalizes the survivors. Dropping without renormalizing leaves sums at 0.984 — a mesh that shrinks toward the origin under load (the check&#x27;s measured failure, 1.616e-02 off unit sum). 2. <strong>The armature modifier is still exactly linear blend skinning</strong> after the limit: every depsgraph-evaluated vertex equals <code>Σ wᵢ · (pose.matrix @ bone.matrix_local.inverted()) @ rest</code>, with the weights <strong>read back from the mesh&#x27;s own deform layer</strong> (<code>v.groups</code>) — the weights on the mesh are the contract, not the weights you meant to write. Measured <code>lbs_err = 2.7e-07</code>. 3. <strong>Pruning must not damage the pose.</strong> Evaluated positions before and after the limit are held within 0.05 (measured 2.8e-03), the pedestal mount stays exactly pinned (Root is unposed), and the pre-limit authoring really carries five influences in the cuffs — otherwise the witness would be vacuous.</p>
 <p>The vertex-group API (<code>v.groups</code>, <code>VertexGroup.add</code>/<code>remove</code>) is stable between Blender 4.5 LTS and 5.1 — the example runs identically on both, which is itself the version witness (measured values match to the digit).</p>
 <p>The render shows the pruned arm mid-pose: the flex cuffs carry the teal accent — the five-influence zones the limit prunes glow at the elbow hinge and wrist, sealed by the bright hoop on the elbow cuff — proof that the limited weights still deform as authored.</p>
 <h2>Run</h2>
@@ -240,7 +240,7 @@ check. Pass --output to also render a still:
 
 SIDES = <span class="n">32</span>
 MAX_INFLUENCES = <span class="n">4</span>              <span class="c"># the engine constraint being witnessed</span>
-BUMP_R = <span class="n">1.8</span>                    <span class="c"># flex-boot blend support; guarantees 5 pre-limit</span>
+BUMP_R = <span class="n">1.8</span>                    <span class="c"># flex-cuff blend support; guarantees 5 pre-limit</span>
 LBS_TOL = <span class="n">5e-4</span>                  <span class="c"># float32 mesh coords vs double pose matrices</span>
 SUM_TOL = <span class="n">1e-5</span>                  <span class="c"># per-vertex weight sum after renormalize</span>
 POSE_TOL = <span class="n">0.05</span>                 <span class="c"># pruning must not move the pose beyond this</span>
@@ -261,7 +261,7 @@ GUNMETAL, ORANGE, RUBBER, ACCENT = <span class="n">0</span>, <span class="n">1</
 
 
 <span class="k">def</span> flex_weights(z):
-    <span class="s">&quot;&quot;&quot;Rich pre-limit weights over all five bones — boots blend broadly.&quot;&quot;&quot;</span>
+    <span class="s">&quot;&quot;&quot;Rich pre-limit weights over all five bones — cuffs blend broadly.&quot;&quot;&quot;</span>
     w = [bump(z, BONE_CENTERS[b]) <span class="k">for</span> b <span class="k">in</span> BONES]
     total = sum(w)
     <span class="k">return</span> [x / total <span class="k">for</span> x <span class="k">in</span> w]
@@ -408,7 +408,7 @@ GUNMETAL, ORANGE, RUBBER, ACCENT = <span class="n">0</span>, <span class="n">1</
 
 <span class="k">def</span> assign_weights(obj, part_of):
     <span class="s">&quot;&quot;&quot;Author the rich pre-limit weights: hard single-bone on armor, broad
-    five-bone bumps in the flex boots.&quot;&quot;&quot;</span>
+    five-bone bumps in the flex cuffs.&quot;&quot;&quot;</span>
     groups = {b: obj.vertex_groups.new(name=b) <span class="k">for</span> b <span class="k">in</span> BONES}
     <span class="k">if</span> len(part_of) != len(obj.data.vertices):
         <span class="k">raise</span> RuntimeError(<span class="s">f&quot;</span><span class="s">part tag count </span>{len(part_of)}<span class="s"> != vert count </span><span class="s">&quot;</span>
@@ -466,7 +466,7 @@ GUNMETAL, ORANGE, RUBBER, ACCENT = <span class="n">0</span>, <span class="n">1</
 <span class="k">def</span> check(obj, arm, groups, pose_before):
     me = obj.data
 
-    <span class="c"># pre-limit witness: the flex boots really carry five influences</span>
+    <span class="c"># pre-limit witness: the flex cuffs really carry five influences</span>
     pre_max = max(len(v.groups) <span class="k">for</span> v <span class="k">in</span> me.vertices)
     <span class="k">if</span> pre_max != <span class="n">5</span>:
         print(<span class="s">f&quot;</span><span class="s">ERROR: pre-limit max influences </span>{pre_max}<span class="s"> != 5 — the rich </span><span class="s">&quot;</span>

--- a/examples/vertex-weight-limit/README.md
+++ b/examples/vertex-weight-limit/README.md
@@ -21,18 +21,18 @@ AI-generated rigging code most often violates silently.
    `bpy.ops.object.vertex_group_limit_total`, the example reads each vertex's
    groups, keeps the top four by weight, `VertexGroup.remove`s the rest, and
    renormalizes the survivors. Dropping without renormalizing leaves sums at
-   0.986 — a mesh that shrinks toward the origin under load (the check's
-   measured failure, 1.438e-02 off unit sum).
+   0.984 — a mesh that shrinks toward the origin under load (the check's
+   measured failure, 1.616e-02 off unit sum).
 2. **The armature modifier is still exactly linear blend skinning** after the
    limit: every depsgraph-evaluated vertex equals
    `Σ wᵢ · (pose.matrix @ bone.matrix_local.inverted()) @ rest`, with the
    weights **read back from the mesh's own deform layer** (`v.groups`) — the
    weights on the mesh are the contract, not the weights you meant to write.
-   Measured `lbs_err = 3.0e-07`.
+   Measured `lbs_err = 2.7e-07`.
 3. **Pruning must not damage the pose.** Evaluated positions before and after
-   the limit are held within 0.05 (measured 3.0e-03), the pedestal mount stays
+   the limit are held within 0.05 (measured 2.8e-03), the pedestal mount stays
    exactly pinned (Root is unposed), and the pre-limit authoring really carries
-   five influences in the boots — otherwise the witness would be vacuous.
+   five influences in the cuffs — otherwise the witness would be vacuous.
 
 The vertex-group API (`v.groups`, `VertexGroup.add`/`remove`) is stable between
 Blender 4.5 LTS and 5.1 — the example runs identically on both, which is itself

--- a/examples/vertex-weight-limit/vertex_weight_limit.py
+++ b/examples/vertex-weight-limit/vertex_weight_limit.py
@@ -34,7 +34,7 @@ import mathutils
 
 SIDES = 32
 MAX_INFLUENCES = 4              # the engine constraint being witnessed
-BUMP_R = 1.8                    # flex-boot blend support; guarantees 5 pre-limit
+BUMP_R = 1.8                    # flex-cuff blend support; guarantees 5 pre-limit
 LBS_TOL = 5e-4                  # float32 mesh coords vs double pose matrices
 SUM_TOL = 1e-5                  # per-vertex weight sum after renormalize
 POSE_TOL = 0.05                 # pruning must not move the pose beyond this
@@ -55,7 +55,7 @@ def bump(z, center, radius=BUMP_R):
 
 
 def flex_weights(z):
-    """Rich pre-limit weights over all five bones — boots blend broadly."""
+    """Rich pre-limit weights over all five bones — cuffs blend broadly."""
     w = [bump(z, BONE_CENTERS[b]) for b in BONES]
     total = sum(w)
     return [x / total for x in w]
@@ -202,7 +202,7 @@ def build_arm():
 
 def assign_weights(obj, part_of):
     """Author the rich pre-limit weights: hard single-bone on armor, broad
-    five-bone bumps in the flex boots."""
+    five-bone bumps in the flex cuffs."""
     groups = {b: obj.vertex_groups.new(name=b) for b in BONES}
     if len(part_of) != len(obj.data.vertices):
         raise RuntimeError(f"part tag count {len(part_of)} != vert count "
@@ -260,7 +260,7 @@ def eval_positions(obj):
 def check(obj, arm, groups, pose_before):
     me = obj.data
 
-    # pre-limit witness: the flex boots really carry five influences
+    # pre-limit witness: the flex cuffs really carry five influences
     pre_max = max(len(v.groups) for v in me.vertices)
     if pre_max != 5:
         print(f"ERROR: pre-limit max influences {pre_max} != 5 — the rich "


### PR DESCRIPTION
## Summary

Follow-up to #83: the armor remodels drifted the measured values the README quotes. Syncs them to the current check output — drop-without-renormalize failure **1.616e-02** (sums at 0.984), `lbs_err = 2.7e-07`, `pose_dev = 2.8e-03` — and finishes the boots→cuffs terminology in script comments.

Comments/docs only. Check re-verified exit 0 on `.scratch/blender-5.1.2-windows-x64/blender.exe` (Blender 5.1.2). Gallery rebuilt; detail HTML re-read.

## Test plan

- [ ] Validate, manifest, counts
- [ ] Blender 5.1 + 4.5 smoke (vertex-weight-limit step)

🤖 Generated with [Kimi Code](https://github.com/MoonshotAI/kimi-cli)