### PR TITLE
docs: restore the Mesh, curves & text README category

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ byte images stay straight 8-bit. Also witnesses `EXR color_mode='RGB'` dropping 
 </tr>
 </table>
 
+</details>
+
+<details>
+<summary><strong>Mesh, curves &amp; text</strong> — 8 examples</summary>
+
 <table>
 <tr>
 <td width="46%" valign="middle">


### PR DESCRIPTION
## Summary
- Commit dcb9b0a (png-exr-alpha) accidentally deleted the `</details>` / `<details><summary>Mesh, curves &amp; text</summary>` boundary in the README example index, merging that category into "Materials, shading & compositing" — a header claiming 6 examples sat over 14.
- Restores the boundary with the category at its current size (8 examples — the original 7 plus vse-cut-list, which was later appended to that table).
- Verified: `<details>`/`</details>` pair 6/6 and every category header count now matches its `### [` entry count (6+8+2+5+2+3 = 26; aggregate counts untouched).

## Evidence
Docs-only change, established by inspection (structure check script output in the verification above); no live Blender run applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)