### PR TITLE
feat: curate landing-page examples to a featured subset

### DIFF
--- a/examples/gallery.json
+++ b/examples/gallery.json
@@ -86,7 +86,8 @@
       "tags": [
         "mesh",
         "bmesh"
-      ]
+      ],
+      "featured_rank": 7
     },
     {
       "name": "shader-node-group",
@@ -170,7 +171,8 @@
       "tags": [
         "constraints",
         "animation"
-      ]
+      ],
+      "featured_rank": 3
     },
     {
       "name": "color-attribute-wheel",
@@ -183,7 +185,8 @@
         "mesh",
         "materials",
         "attributes"
-      ]
+      ],
+      "featured_rank": 8
     },
     {
       "name": "parent-inverse-orrery",
@@ -219,7 +222,8 @@
       "tags": [
         "armature",
         "depsgraph"
-      ]
+      ],
+      "featured_rank": 6
     },
     {
       "name": "text-version-stamp",
@@ -368,7 +372,8 @@
       "tags": [
         "rendering",
         "objects"
-      ]
+      ],
+      "featured_rank": 4
     },
     {
       "name": "collision-hull-proxy",
@@ -380,7 +385,8 @@
       "tags": [
         "bmesh",
         "mesh"
-      ]
+      ],
+      "featured_rank": 5
     },
     {
       "name": "custom-normals-shade",
@@ -456,7 +462,8 @@
       "tags": [
         "bmesh",
         "mesh"
-      ]
+      ],
+      "featured_rank": 2
     },
     {
       "name": "car-mirror-symmetry",
@@ -468,7 +475,8 @@
       "tags": [
         "modifiers",
         "depsgraph"
-      ]
+      ],
+      "featured_rank": 1
     },
     {
       "name": "attribute-domain-shear",

--- a/scripts/site/build_site.py
+++ b/scripts/site/build_site.py
@@ -250,6 +250,16 @@ def load_examples(repo_root: Path) -> list[dict]:
     return examples
 
 
+def pick_featured(examples: list[dict]) -> list[dict]:
+    """Landing-page showcase subset: entries carrying a ``featured_rank``
+    integer in gallery.json, sorted by rank. Returns [] when nothing is
+    curated; the template then falls back to the full list."""
+    return sorted(
+        (ex for ex in examples if isinstance(ex.get("featured_rank"), int)),
+        key=lambda ex: ex["featured_rank"],
+    )
+
+
 def load_mcp_tools(repo_root: Path) -> list[dict]:
     mcp_file = repo_root / "mcp-tools.json"
     if not mcp_file.is_file():
@@ -365,6 +375,7 @@ def main():
     skills = parse_skills(repo_root)
     rules = parse_rules(repo_root)
     examples = load_examples(repo_root)
+    featured = pick_featured(examples)
     mcp_tools = load_mcp_tools(repo_root)
     mcp_grouped = group_by_category(mcp_tools)
     changelog = parse_changelog(repo_root)
@@ -378,6 +389,8 @@ def main():
         "rule_count": len(rules),
         "examples": examples,
         "example_count": len(examples),
+        "featured_examples": featured,
+        "featured_count": len(featured),
         "snippet_count": len(plugin.get("snippets", [])),
         "template_count": len(plugin.get("templates", [])),
         # basenames for display: snippets/foo-bar.py -> foo-bar

--- a/scripts/site/template.html.j2
+++ b/scripts/site/template.html.j2
@@ -153,6 +153,11 @@
       text-overflow: ellipsis; }
     .panel-cta { display: inline-block; margin-top: 1.25rem; font-weight: 500; font-size: 0.9rem; color: var(--select); }
     .panel-cta:hover { text-decoration: underline; }
+    /* featured subset: gallery link is the section's primary call to action */
+    .cta-row { margin: -0.25rem 0 1.5rem; }
+    .btn-cta { display: inline-block; background: var(--select); color: #1a1b1e; font-weight: 500;
+      font-size: 0.92rem; border-radius: 4px; padding: 0.55rem 1.15rem; transition: filter 0.15s; }
+    .btn-cta:hover { filter: brightness(1.12); }
 
     /* skills */
     .skill-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0.4rem 2.25rem; }
@@ -284,19 +289,21 @@
   <main id="main">
 
   {% if examples %}
+  {% set shown = featured_examples if featured_examples else examples %}
   <section class="panel" id="examples">
     <div class="panel-head">
       <span class="caret" aria-hidden="true">&#9662;</span>
       <span class="hud">Render Result</span>
-      <span class="hud count">{{ example_count }} frames</span>
+      <span class="hud count">{% if featured_examples %}{{ featured_count }} of {% endif %}{{ example_count }} frames</span>
     </div>
     <div class="panel-body">
       <h2>Every render here is a CI artifact.</h2>
       <p class="lede">These aren't mockups. Each example runs headless on Blender 4.5 LTS and 5.1 in the
         smoke workflow, asserts its own correctness, and exits non-zero if the API drifted. The render is
         what the code produced.</p>
+      <p class="cta-row"><a class="btn-cta" href="gallery/">Browse all {{ example_count }} examples in the gallery &rarr;</a></p>
       <div class="render-grid">
-        {% for ex in examples %}
+        {% for ex in shown %}
         <a class="render-card" href="gallery/{{ ex.name }}/">
           <img src="{{ ex.heroSite }}" alt="{{ ex.name }} render" loading="lazy" width="1280" height="720" />
           <div class="render-meta">


### PR DESCRIPTION
## What this is

The landing page's **Render Result** section rendered all **40** example cards in a two-column grid — 9,948px of scroll at 1280px (24,788px at 390px), the longest page on the site. PR #113 gave `/gallery/` search, filters, and density controls; this PR makes the landing page a showcase that delegates enumeration to the gallery. No search/filter/toggle is added to the landing page — that is what `/gallery/` is for.

All changes go through the generators (`scripts/site/build_site.py` + `scripts/site/template.html.j2`, driven by `examples/gallery.json`); no generated file is hand-edited (`docs/index.html` is a gitignored build output; `docs/gallery/` regenerates byte-identical — verified).

## Featured-selection mechanism

- `examples/gallery.json` entries may now carry a **`featured_rank`** integer.
- `build_site.py::pick_featured()` sorts entries with a rank into `featured_examples` and passes it to the template. When nothing is curated (empty list), the template falls back to the full list — the section can never go blank.
- No hand-maintained duplicate list in the generator or template: the data file is the only place the set lives.

## Featured set and why

Rank order as rendered: **car-mirror-symmetry, soccer-ball-goldberg, damped-track-aim, light-link-studio, collision-hull-proxy, armature-bend, bmesh-gear, color-attribute-wheel.**

The two pinned calibration members (`armature-bend`, `bmesh-gear` — third member `damped-track-aim` also included) plus the most striking recent work, ordered for subject and palette variety: automotive (Mirror), sports geometry (Goldberg), constraints (golden needle array), lighting narrative (linked/unlinked), game pipeline (wireframe hull), armature weights (pink/teal gradient), bmesh (gold gear), color science (rainbow wheel). Renders were reviewed individually, not picked from names.

## Section changes

- Grid shows the 8 featured cards; anatomy, dark theme, typography unchanged.
- Panel-head counter is now honest: **`8 of 40 frames`** (was `40 frames`).
- Gallery link is the section's primary CTA: an orange button above the grid ("Browse all 40 examples in the gallery →"), visible within the first viewport of the section. The original text link remains below the grid as a secondary.

## Landing-page height (live measurement, all lazy images loaded)

| Viewport | Before (current live site) | After (this branch, local) |
| --- | --- | --- |
| 1280×800 | 9,948px | **4,847px (−51.3%)** |
| 390×844 | 24,788px | **10,203px (−58.8%)** |

## Verification — live run (Playwright, Chromium 148, local `python -m http.server` over `docs/`)

26 assertions, all passing; screenshots reviewed, not just load-checked:

- Desktop: 8 cards in `featured_rank` order, counter text, CTA above the grid and within the first ~1.1 viewports (y≈847), href `gallery/`.
- Mobile 390px: 8 cards, single column, counter, CTA above grid.
- No-JS landing: 8 featured cards render, CTA present, and clicking it navigates to `/gallery/` where all 40 cards render.
- **`/gallery/` regression:** compact default, search (`needle` → 1), tag AND search (`bmesh`+`gear` → 1), hash written and restored on a fresh page, detailed toggle, sticky controls at exactly `top:46`, no-JS 40/40 cards. PR #113 behavior intact. (The gallery's own CSS/JS was not touched; its build output is byte-identical on this branch.)
- **Alt text:** re-read the 8 generated landing `<img alt>`s (`{name} render` — the landing template never used teaches-based alts, so the dotted-path truncation class does not apply); complete. All 40 `/gallery/` alts untouched.

## Other generated pages with the same all-inline problem

Checked while in the template: **none pathological.** The landing page's Skills section lists 12 compact two-line rows (~700px), Rules a 6-row table, Snippets/Templates link chips, Changelog 2 entries — all enumeration-sized and appropriate for a landing page. `/gallery/` detail pages are one-example-each by construction. No further action needed.

## Inspection only (not live-run)

- Firefox/Safari rendering (all captures Chromium).
- The empty-`featured_rank` fallback path (template renders all 40 when nothing is curated) — verified by code reading; the shipped config has 8 ranked entries.

## Release note

`feat:` subject — release.yml will cut a minor on merge. `docs/index.html` is rebuilt by the Pages deploy from the same template + data, so served and reviewed output cannot drift.
