### PR TITLE
chore: add gitattributes, CODEOWNERS, and GitHub templates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Line endings. JSON and Markdown stay LF so Windows checkouts
+# do not churn gallery.json, plugin.json, or skill files.
+*.json text eol=lf
+*.md text eol=lf
+
+# Binary. Gallery stills and any future .blend fixtures.
+*.webp binary
+*.blend binary

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Enforced only when branch protection on `main` enables
+# "Require a pull request before merging" AND "Require review from Code Owners".
+# Without that setting this file documents ownership, it does not gate merges.
+
+* @TMHSDigital
+
+/.github/ @TMHSDigital
+/scripts/ @TMHSDigital
+/.cursor-plugin/ @TMHSDigital

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,82 @@
+name: Bug report
+description: Something in a skill, rule, snippet, template, example, or CI is wrong
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. For security issues, do not file a public issue — open a [Security Advisory](https://github.com/TMHSDigital/Blender-Developer-Tools/security/advisories/new) instead.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Skill
+        - Rule
+        - Snippet
+        - Template
+        - Example
+        - Gallery / docs
+        - CI workflows
+        - Plugin manifest
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: affected
+    attributes:
+      label: Affected path
+      description: Skill directory, example name, snippet filename, workflow, etc.
+      placeholder: e.g. skills/vse-python/ or examples/vse-cut-list/
+    validations:
+      required: true
+
+  - type: dropdown
+    id: blender
+    attributes:
+      label: Blender series
+      options:
+        - 5.2 LTS
+        - 5.1
+        - 4.5 LTS
+        - Multiple / cross-version
+        - Not Blender-runtime (docs/CI only)
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Minimal steps. Include the exact binary path and `blender --version` output if this is a runtime bug.
+      placeholder: |
+        1. blender --background --python examples/vse-cut-list/vse_cut_list.py -- --check-pixels
+        2. Observe …
+        3. Expected …
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual
+      description: Include the measured error / exit code. An assertion that cannot fail witnesses nothing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/TMHSDigital/Blender-Developer-Tools/security/advisories/new
+    about: Report a security issue privately via GitHub Security Advisory. Do not open a public issue for vulnerabilities.
+  - name: Roadmap / candidate pool
+    url: https://github.com/TMHSDigital/Blender-Developer-Tools/blob/main/ROADMAP.md
+    about: Check ROADMAP.md before requesting new skills, snippets, or examples. Shipped items are struck through there.

--- a/.github/ISSUE_TEMPLATE/content.yml
+++ b/.github/ISSUE_TEMPLATE/content.yml
@@ -1,0 +1,47 @@
+name: Content request
+description: Propose a new skill, rule, snippet, template, or example
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Skim [ROADMAP.md](https://github.com/TMHSDigital/Blender-Developer-Tools/blob/main/ROADMAP.md) first. Struck-through candidate-pool items already shipped.
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind
+      options:
+        - New skill
+        - New rule
+        - New snippet
+        - New template
+        - New example
+        - Improvement to existing content
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: contract
+    attributes:
+      label: API contract
+      description: What should a headless script be able to assert? Name the RNA types / operators. If this is a version split, say which series diverge.
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why it belongs here
+      description: The AI mistake this catches, or the gap versus what the python_api notes already list.
+    validations:
+      required: true
+
+  - type: textarea
+    id: witness
+    attributes:
+      label: Witness plan
+      description: Cheap headless asserts, a .blend fixture, or not witnessable in `--background`. Do not propose a gallery render as the only proof.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+## Summary
+
+<!-- One or two sentences on why, not what. -->
+
+## Type
+
+- [ ] `feat` — new skill / rule / snippet / template / example (minor bump)
+- [ ] `fix` — correction to existing content or a broken contract (patch bump)
+- [ ] `docs` / `chore` / `ci` / `refactor` — no release; `release.yml` still runs and should exit without a tag
+
+Squash-merge subject is what the release workflow scans. Keep it conventional.
+
+## Evidence
+
+Label every claim.
+
+- **live-run-proven:** exact binary path + the version that binary printed (`blender --version`). Headless harness only. Live MCP does not count.
+- **inspection-only:** read the skill / diff / RNA docs; no process ran.
+
+`blender-smoke.yml` has no `push` trigger. Post-merge smoke evidence is the PR-head 5.2 + 4.5 jobs (state the versions from those logs).
+
+## Release-owned fields — do not hand-edit
+
+`VERSION`, `CHANGELOG.md`, CLAUDE.md `**Version:**`, ROADMAP.md `**Current:**`, `.cursor-plugin/plugin.json` `"version"`. The release pipeline rewrites those. Do not bump `standards-version` unless the fleet stamp actually moved.
+
+## Checklist
+
+- [ ] Explicit paths only (`git add` never `-A` / `.`). Leave unstaged Cursor-injected `CLAUDE.md` hunks.
+- [ ] Counts in `README.md` match disk if content was added or removed (`validate-counts`).
+- [ ] Manifest arrays list every new skill / rule / snippet / template / example (`validate-manifest`). Do not touch the `"version"` line.
+- [ ] New example: `gallery.json`, smoke step, README row, hero/preview webp, `python scripts/build_gallery.py`, framing / contact-sheet gates as in `CLAUDE.md`.
+- [ ] Every new check was falsified once (break it, non-zero exit, restore) — or this PR has no new check.
+- [ ] DCO `Signed-off-by:` on every commit ([CONTRIBUTING.md](CONTRIBUTING.md)).
+- [ ] No credentials, business emails, or local filesystem paths.
+
+## Test plan
+
+<!-- What you ran, on which Blender binary, exit codes. -->
+
+## Linked issues
+
+<!-- Closes #123 -->


### PR DESCRIPTION
## Summary

- `.gitattributes`: `*.json` / `*.md` text `eol=lf`; `*.webp` and `*.blend` binary.
- `.github/CODEOWNERS` (`* @TMHSDigital`).
- Issue forms (bug + content request) and a PR template that encodes live-run-proven vs inspection-only, the release-owned field list, and DCO.

Left alone: `site.json`, `standards-version: 1.10.0`. No content-count change.

## Evidence

- **inspection-only:** file presence and attribute rules. No Blender run.

## Test plan

- [ ] validate + drift green (no count/manifest change)
- [ ] blender-smoke 5.2 + 4.5 green on this head (hygiene only; same examples)
- [ ] Socket not pending/failing
- [ ] squash subject stays `chore:` so `release.yml` runs and **does not tag**