### PR TITLE
ci: opt-in Blender 5.1 smoke via needs-5.1 and dispatch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@ Label every claim.
 - **live-run-proven:** exact binary path + the version that binary printed (`blender --version`). Headless harness only. Live MCP does not count.
 - **inspection-only:** read the skill / diff / RNA docs; no process ran.
 
-`blender-smoke.yml` has no `push` trigger. Post-merge smoke evidence is the PR-head 5.2 + 4.5 jobs (state the versions from those logs).
+`blender-smoke.yml` has no `push` trigger. Post-merge smoke evidence is the PR-head 5.2 + 4.5 jobs (state the versions from those logs). Apply `needs-5.1` when 5.1 must be CI-proven on the PR; default matrix does not include it.
 
 ## Release-owned fields — do not hand-edit
 

--- a/.github/workflows/blender-smoke.yml
+++ b/.github/workflows/blender-smoke.yml
@@ -2,37 +2,88 @@ name: Blender Smoke Test
 
 # Executes the snippets' and skills' headline examples inside REAL Blender, headless,
 # on the current stable (5.2.x LTS) and the fallback LTS (4.5.x) on every PR,
-# plus 5.1.x on the weekly cron, and fails on any error or
+# plus 5.1.x on the weekly cron, the opt-in `needs-5.1` PR label, or a
+# workflow_dispatch series input, and fails on any error or
 # empty-output assertion. Shipped examples go through tests/smoke/run_example.py
 # (catalog.json): SKIP is exit 77 + SMOKE_SKIP below --min-version, never exit 0.
 # Post-exit sidecars are opt-in. A leg with zero PASSes is red.
 # py_compile (in validate.yml) cannot catch API-level regressions
 # like the EEVEE-id inversion, the slotted-actions boundary, the driver TypeError, or the
 # dead SDF link -- this gate runs the code so those surface in CI, not in users' files.
+#
+# Default PR matrix stays 5.2 + 4.5. `labeled` is in pull_request.types so
+# applying `needs-5.1` starts a 5.1 job; other labels are ignored and must
+# not cancel an in-progress default run. Auto-label does not apply needs-5.1.
+# Manual dispatch: Actions > Blender Smoke Test > Run workflow > pick series.
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      series:
+        description: Blender series to smoke (single version, on-demand)
+        required: true
+        type: choice
+        options:
+          - "5.2"
+          - "5.1"
+          - "4.5"
+        default: "5.2"
   schedule:
     - cron: "0 7 * * 1"   # weekly, Monday 07:00 UTC
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: read
 
 concurrency:
-  group: blender-smoke-${{ github.ref }}
+  # Isolate labeled runs so auto-label (`ci`, `documentation`, ...) does not
+  # cancel the default 4.5/5.2 jobs. synchronize still cancels the previous
+  # synchronize on the same PR.
+  group: blender-smoke-${{ github.event.pull_request.number || github.ref }}${{ github.event.action == 'labeled' && format('-label-{0}', github.event.label.name) || '' }}
   cancel-in-progress: true
 
 jobs:
+  resolve-matrix:
+    name: Resolve smoke matrix
+    runs-on: ubuntu-latest
+    if: github.event.action != 'labeled' || github.event.label.name == 'needs-5.1'
+    outputs:
+      series: ${{ steps.set.outputs.series }}
+    steps:
+      - id: set
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          DISPATCH_SERIES: ${{ github.event.inputs.series }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            json='["5.2","5.1","4.5"]'
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            json=$(printf '["%s"]' "$DISPATCH_SERIES")
+          elif [ "$EVENT_ACTION" = "labeled" ]; then
+            json='["5.1"]'
+          elif echo ",$PR_LABELS," | grep -q ",needs-5.1,"; then
+            json='["5.2","5.1","4.5"]'
+          else
+            json='["5.2","4.5"]'
+          fi
+          echo "series=$json" >> "$GITHUB_OUTPUT"
+          echo "Smoke matrix: $json"
+
   smoke:
     name: Blender ${{ matrix.series }} smoke
+    needs: resolve-matrix
+    if: needs.resolve-matrix.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        series: ${{ github.event_name == 'schedule' && fromJSON('["5.2","5.1","4.5"]') || fromJSON('["5.2","4.5"]') }}
+        series: ${{ fromJSON(needs.resolve-matrix.outputs.series) }}
     steps:
       - uses: actions/checkout@v7
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,10 @@ way, and a one-paragraph rationale. 30 to 80 lines is the right size.
   the manifest `version` line (see `release.yml` below) — never hand-edit it.
 - `blender-smoke.yml` executes every shipped example (check-only, no render)
   plus snippet/template smoke tests inside REAL headless Blender, on
-  5.2 LTS and 4.5 LTS for every PR (5.1 on the weekly cron). Examples run
+  5.2 LTS and 4.5 LTS for every PR. 5.1 is weekly cron, the opt-in
+  `needs-5.1` PR label (`pull_request` types include `labeled`), or
+  `workflow_dispatch` with a `series` input. Auto-label does not apply
+  `needs-5.1`. Contributor-facing notes live in CONTRIBUTING.md. Examples run
   through `tests/smoke/run_example.py` (catalog: `tests/smoke/catalog.json`).
   SKIP is exit 77 plus a `SMOKE_SKIP:` reason, and only when `--min-version`
   is above this Blender; exit 0 with that marker is a vacuous pass and fails.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ AI asset pipeline track: `decimate_to_budget.py`, `convex_hull_collider.py`, `lo
 
 Runnable scripts at `examples/<name>/`, each asserting a real API contract with
 deterministic checks (exit non-zero on failure) and optionally rendering a still via
-`--output`. All of them run headless on Blender 5.2 LTS and 4.5 LTS in `blender-smoke.yml` (5.1 on the weekly cron);
+`--output`. All of them run headless on Blender 5.2 LTS and 4.5 LTS in `blender-smoke.yml` (5.1 on the weekly cron, the `needs-5.1` PR label, or manual dispatch);
 their renders ship in the site gallery at `docs/gallery/`. `examples/gallery.json` is the
 gallery's source of truth. When authoring a new one, copy the anatomy of
 `examples/bmesh-gear/` (script structure, README shape, dark-studio render recipe) and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,19 @@ else:
     ...
 ```
 
+## Blender smoke on pull requests
+
+Default PR smoke is Blender 5.2 and 4.5 (`.github/workflows/blender-smoke.yml`).
+5.1 is not in that matrix.
+
+- Apply the `needs-5.1` label when the change can diverge on 5.1 (bake, UV
+  RNA, version-branched API). That starts a 5.1 smoke job. Auto-label will
+  not apply this; it is opt-in.
+- Run any series on demand: Actions > Blender Smoke Test > Run workflow,
+  pick the branch and the `series` input.
+- Monday 07:00 UTC cron still runs 5.2, 5.1, and 4.5. Do not treat cron as
+  PR evidence.
+
 ## Standards-version Markers
 
 Files that participate in ecosystem drift checking must carry a `standards-version` marker matching the current meta-repo `STANDARDS_VERSION` (which is decoupled from this repo's `VERSION`):

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ blender --background --python examples/bmesh-gear/bmesh_gear.py --
 | Version | Status |
 | --- | --- |
 | Blender 5.2 LTS | Primary target (current stable; all examples assume 5.2 unless a 4.5 path is shown) |
-| Blender 5.1 | Prior stable (weekly smoke only) |
+| Blender 5.1 | Prior stable (weekly cron; PR via `needs-5.1` or manual dispatch) |
 | Blender 4.5 LTS | Fallback supported (skills show both code paths where 4.x and 5.x APIs diverge) |
 
 ## Examples
 
 Runnable, smoke-gated demos live in [`examples/`](examples/) — each is executed headless on
-Blender 5.2 LTS and 4.5 LTS by the `blender-smoke` workflow (5.1 on the weekly cron), so the screenshots reflect code
+Blender 5.2 LTS and 4.5 LTS by the `blender-smoke` workflow (5.1 on the weekly cron, the `needs-5.1` PR label, or manual dispatch), so the screenshots reflect code
 that actually runs. Browse them all with filters and full-size renders in the
 **[examples gallery](https://tmhsdigital.github.io/Blender-Developer-Tools/gallery/)**,
 or expand a category below.

--- a/examples/bmesh-gear/bmesh_gear.py
+++ b/examples/bmesh-gear/bmesh_gear.py
@@ -194,6 +194,7 @@ def main():
     p.add_argument("--engine", default="eevee", choices=("eevee", "cycles"),
                    help="render engine for --output (cycles for GPU-less hosts)")
     args = p.parse_args(argv)
+    raise SystemExit(1)  # phase-4 canary: prove 5.1 smoke fails
 
     obj = build_gear()
     code = check(obj)

--- a/examples/bmesh-gear/bmesh_gear.py
+++ b/examples/bmesh-gear/bmesh_gear.py
@@ -194,7 +194,6 @@ def main():
     p.add_argument("--engine", default="eevee", choices=("eevee", "cycles"),
                    help="render engine for --output (cycles for GPU-less hosts)")
     args = p.parse_args(argv)
-    raise SystemExit(1)  # phase-4 canary: prove 5.1 smoke fails
 
     obj = build_gear()
     code = check(obj)


### PR DESCRIPTION
## Summary

Closes #134. Opt-in 5.1 smoke without putting 5.1 on every PR.

This repo has no `ci.yml`. The existing lever is `blender-smoke.yml`'s empty `workflow_dispatch: {}`. This PR adds a `series` choice input there, plus a `needs-5.1` label path. `pull_request.types` was previously unset (GitHub default: opened / synchronize / reopened only). `labeled` is now listed explicitly so applying the label starts a run. Monday cron is unchanged. Default PR matrix stays 4.5 and 5.2.

Auto-label does **not** apply `needs-5.1`. It still only applies path labels (`ci`, `documentation`, ...). GITHUB_TOKEN label events do not retrigger workflows; a human (or REST) applying `needs-5.1` does.

## B2 gate-failure proof (live-run-proven)

`needs-5.1` is **left applied** on this PR so the final head keeps a 5.1 job.

### 1. Absent by default (no `needs-5.1`)

`gh pr checks 137` immediately after open, before the label. No `Blender 5.1 smoke` row. Smoke run: https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691306483 (jobs: Resolve smoke matrix, Blender 4.5, Blender 5.2 only).

```
Blender 4.5 smoke	pending	https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691306483/job/103546936589
Blender 5.2 smoke	pending	https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691306483/job/103546936593
Auto-label by path	pass	https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691306490/job/103546923313
Ecosystem drift check	pass	https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691306577/job/103546923553
Resolve smoke matrix	pass	https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691306483/job/103546923482
Socket Security: Project Report	pass
Socket Security: Pull Request Alerts	pass
Validate content counts	pass
Validate plugin manifest	pass
Validate smoke harness protocol	pass
Validate structure and frontmatter	pass
```

That same run later finished 4.5 pass 3m10s / 5.2 pass 4m27s. Still no 5.1 job.

### 2. Triggers on label

Applied `needs-5.1` via REST (`gh pr edit --add-label` hit the projectCards GraphQL deprecation). Labeled run matrix log: `Smoke matrix: ["5.1"]`. 5.1 job appeared and completed.

Labeled run: https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691361129

```
Blender 5.1 smoke	pass	4m17s	https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691361129/job/103547080593
Resolve smoke matrix	pass	3s	https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691361129/job/103547070877
Blender 4.5 smoke	pass	3m10s	https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691306483/job/103546936589
Blender 5.2 smoke	pass	4m27s	https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691306483/job/103546936593
```

### 3. Canary turns 5.1 red, then revert is green

Canary: `SystemExit(1)` at the start of `examples/bmesh-gear` `main()` (`0d32dbd`). Synchronize with the label on, matrix all three series.

Failing run: https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691589680

```
Blender 4.5 smoke	fail	1m15s	https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691589680/job/103547687638
Blender 5.1 smoke	fail	1m14s	https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691589680/job/103547687642
Blender 5.2 smoke	fail	1m5s	https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691589680/job/103547687660
Resolve smoke matrix	pass	3s	https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691589680/job/103547675650
```

Revert `dc8072c`. Green run: https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691713403

```
Blender 4.5 smoke	pass	3m16s	https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691713403/job/103548023249
Blender 5.1 smoke	pass	4m21s	https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691713403/job/103548023220
Blender 5.2 smoke	pass	3m57s	https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691713403/job/103548023215
Resolve smoke matrix	pass	4s	https://github.com/TMHSDigital/Blender-Developer-Tools/actions/runs/34691713403/job/103548010665
```

## Documentation (inspection)

One how-to section in `CONTRIBUTING.md` after Blender Version Targeting (that is where contributors already look for version policy). Pointers: workflow file header, README 5.1 table row + examples blurb, AGENTS.md CI/CD bullet, PR template evidence line.

## Evidence labels

- **live-run-proven:** B2 check lists and run URLs above; 5.1 is not vacuous
- **inspection-only:** no `ci.yml` in this repo; auto-label allow-list; Monday cron cron expression unchanged; default matrix still 4.5+5.2 on unlabeled PRs

## Out of scope

Agent bridge. LICENSE / #131. Baking/UV (Phase 5). VERSION / CHANGELOG / release.yml. Monday cron schedule and default PR version matrix. Examples/skills/snippets/rules/templates except the reverted canary. Exit-code cleanup is #136, not this PR.
