### PR TITLE
docs: write down exit-code roles and the smoke coverage model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,9 @@ way, and a one-paragraph rationale. 30 to 80 lines is the right size.
   5.2 LTS and 4.5 LTS for every PR. 5.1 is weekly cron, the opt-in
   `needs-5.1` PR label (`pull_request` types include `labeled`), or
   `workflow_dispatch` with a `series` input. Auto-label does not apply
-  `needs-5.1`. Contributor-facing notes live in CONTRIBUTING.md. Examples run
+  `needs-5.1`. Contributor-facing notes for the smoke lever, the deliberate
+  lack of a `push` trigger, Pages path filters, and the three-role exit-code
+  convention live in CONTRIBUTING.md. Examples run
   through `tests/smoke/run_example.py` (catalog: `tests/smoke/catalog.json`).
   SKIP is exit 77 plus a `SMOKE_SKIP:` reason, and only when `--min-version`
   is above this Blender; exit 0 with that marker is a vacuous pass and fails.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,37 @@ Default PR smoke is Blender 5.2 and 4.5 (`.github/workflows/blender-smoke.yml`).
   pick the branch and the `series` input.
 - Monday 07:00 UTC cron still runs 5.2, 5.1, and 4.5. Do not treat cron as
   PR evidence.
+- **There is deliberately no `push` trigger on `blender-smoke.yml`.**
+  Squash-merging a green PR makes `main` identical to the content already
+  smoke-tested, so a push job would re-prove the same tree at double the
+  CI cost. Absence of post-merge smoke is not a coverage gap.
+- **`pages.yml` is path-filtered.** A workflow-or-docs-only merge does not
+  deploy Pages. Observed on `13ea521` (`ci:` #137): Validate, drift-check,
+  and Release ran; Pages did not. Intentional, not a failed job.
+
+## Exit codes
+
+Three roles, not one global table. Do not copy a code from one script into
+another and assume it means the same thing. `9` is a valid sequential-check
+code; there is no rule against it.
+
+**Per-script exits** (examples and headless templates). `0` success. `2`
+argument or usage error, matching argparse. `3` and above for that script's
+own sequential check failures, in the order the checks run. These codes are
+file-local and are not portable. `no-mesh` is `2` in
+`templates/headless-batch-script-template/` and `5` in
+`templates/ai-asset-pipeline-template/`; both are correct. Copy a template's
+own table from that template, not from this paragraph.
+
+**FATAL wrapper.** `sys.exit(1)` on an uncaught exception in the `__main__`
+guard. Uniform across the examples. `1` means crashed, never a named check.
+
+**Smoke protocol.** Owned by `tests/` and the runner, not by product check
+tables. `0` pass, `1` fail (`tests/smoke/run_example.py`,
+`tests/check_import_export_rules.py`), `77` skip (`tests/smoke/canary_skip.py`,
+and the product scripts that self-skip: `examples/gn-bundle-roundtrip/`,
+`examples/exit-pre-sidecar/`). A script under test prints `SMOKE_SKIP:` and
+exits 77; the runner records SKIP and returns 0 so the YAML step stays green.
 
 ## Standards-version Markers
 


### PR DESCRIPTION
## Summary

Closes #136 as an invalid premise, not as a code bug.

Exit 9 is within `2+`. 26 example scripts use 9 for a sequential check. `export-preset-axis --same-axis` exiting 9 is the documented falsifier. No executable code changed. No `needs-5.1` label: this PR makes no three-version claim.

## Where it landed

`CONTRIBUTING.md` (Exit codes + expanded Blender smoke). That is the existing contributor-conventions file (version targeting, smoke lever, DCO). No `standards/` directory in this repo. `AGENTS.md` only points here so agents do not grow a second copy.

## Task 1 (live-run-proven this session)

Commands: `rg -n "sys\.exit|SystemExit|exit\(" --type py` (workspace Grep), then an AST walk over `e:\Blender-Developer-Tools\**/*.py` excluding `.git` / `.scratch` / `docs`. Assert-on-9: Grep in `blender-smoke.yml`, `tests/`, `scripts/`.

| Claim | Inherited | This session | Resolution |
| --- | --- | --- | --- |
| Highest product sequential code | 21 in `gltf-export-roundtrip` | **21**, same file, codes 3–21 | match |
| Example scripts using 9 | 26 | **26** | match |
| `sys.exit(1)` FATAL wrappers | 64 | **58** AST `sys.exit(1)` (54 examples + 3 `tests/` + `scripts/site/build_site.py`). **64** is any integer literal `1` including `return 1` | inherited count mixed FATAL with harness `return 1`; docs use the role, not the 64 |
| Smoke `0` / `1` / `77` | as listed | `run_example.py` fail=`return 1`; `check_import_export_rules.py` `return 1`; `canary_skip.py` `sys.exit(77)`; `gn-bundle-roundtrip` and `exit-pre-sidecar` `return 77` + `SMOKE_SKIP:` | match |
| Assert on 9 | none | `tests/` and `scripts/`: no hits. `blender-smoke.yml`: only `[0-9]+` in the Blender tarball regex | match |

**inspection-only:** no-mesh is 2 vs 5 in the two headless templates (read `script.py` / `pipeline.py`).

## Out of scope (unchanged)

Any exit value. `export-preset-axis` behavior. New rule/checker/`validate.yml`. Bake/UV. Agent bridge. LICENSE / #131. VERSION / CHANGELOG / release.yml. `blender-smoke.yml` / `pages.yml` files.

Follow-up (report-mode README check, not this PR): #138.
